### PR TITLE
멤버 소속 팀 리스트 조회, 팀 페이지 url 컬럼 삭제

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/controller/MemberController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/MemberController.java
@@ -44,9 +44,4 @@ public class MemberController {
         memberInfoService.updateMemberInfo(jwtMemberDetail.getId(), request);
     }
 
-    @GetMapping("/teams")
-    @Operation(summary="사용자가 속한 팀 정보 조회 API")
-    public ResponseEntity<List<TeamInfoResponse>> getMemberTeamInfo(@TokenMember JwtMemberDetail jwtMemberDetail){
-        return ResponseEntity.ok().body(memberInfoService.getMemberTeamInfo(jwtMemberDetail.getId()));
-    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/MemberController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.gdsc_knu.official_homepage.annotation.TokenMember;
 import com.gdsc_knu.official_homepage.authentication.jwt.JwtMemberDetail;
 import com.gdsc_knu.official_homepage.dto.member.MemberRequest;
 import com.gdsc_knu.official_homepage.dto.member.MemberResponse;
+import com.gdsc_knu.official_homepage.dto.member.TeamInfoResponse;
 import com.gdsc_knu.official_homepage.service.MemberInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +14,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Member", description = "사용자 정보 관련 API")
 @RestController
@@ -39,5 +42,11 @@ public class MemberController {
     public void updateMemberInfo(@TokenMember JwtMemberDetail jwtMemberDetail,
                                  @ModelAttribute MemberRequest.Update request){
         memberInfoService.updateMemberInfo(jwtMemberDetail.getId(), request);
+    }
+
+    @GetMapping("/teams")
+    @Operation(summary="사용자가 속한 팀 정보 조회 API")
+    public ResponseEntity<List<TeamInfoResponse>> getMemberTeamInfo(@TokenMember JwtMemberDetail jwtMemberDetail){
+        return ResponseEntity.ok().body(memberInfoService.getMemberTeamInfo(jwtMemberDetail.getId()));
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/TeamController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/TeamController.java
@@ -1,6 +1,10 @@
 package com.gdsc_knu.official_homepage.controller;
 
+import com.gdsc_knu.official_homepage.annotation.TokenMember;
+import com.gdsc_knu.official_homepage.authentication.jwt.JwtMemberDetail;
+import com.gdsc_knu.official_homepage.dto.member.TeamInfoResponse;
 import com.gdsc_knu.official_homepage.dto.team.TeamResponse;
+import com.gdsc_knu.official_homepage.service.MemberInfoService;
 import com.gdsc_knu.official_homepage.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,15 +16,23 @@ import java.util.List;
 
 @Tag(name = "Team", description = "팀 관련 API")
 @RestController
-@RequestMapping("api/team")
+@RequestMapping("/api/team")
 @RequiredArgsConstructor
 public class TeamController {
     private final TeamService teamService;
+    private final MemberInfoService memberInfoService;
 
     @GetMapping("/{teamId}/member")
     @Operation(summary = "팀원 정보 조회 API",
             description = "해당 팀의 팀원목록(유저 ID, 이름, 직렬)을 반환합니다. (미배치된 팀은 조회되지 않습니다.)")
     public ResponseEntity<List<TeamResponse.MemberInfo>> getTeamMembers(@PathVariable("teamId") Long teamId) {
         return ResponseEntity.ok().body(teamService.getTeamMember(teamId));
+    }
+
+    @GetMapping()
+    @Operation(summary="현재 로그인한 사용자가 속한 팀 정보 조회 API",
+            description = "현재 로그인한 사용자가 속한 팀 정보(팀 ID, 팀 이름) 리스트를 반환합니다.")
+    public ResponseEntity<List<TeamInfoResponse>> getMemberTeamInfo(@TokenMember JwtMemberDetail jwtMemberDetail){
+        return ResponseEntity.ok().body(memberInfoService.getMemberTeamInfo(jwtMemberDetail.getId()));
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/memberStatus/AdminMemberResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/memberStatus/AdminMemberResponse.java
@@ -38,9 +38,7 @@ public class AdminMemberResponse {
                 .phoneNumber(member.getPhoneNumber())
                 .teams(member.getMemberTeams().stream()
                         .map(MemberTeam::getTeam)
-                        .map(team -> TeamInfoResponse.builder()
-                                .teamName(team.getTeamName())
-                                .build())
+                        .map(TeamInfoResponse::new)
                         .toList())
                 .role(member.getRole())
                 .build();

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/memberStatus/AdminMemberResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/memberStatus/AdminMemberResponse.java
@@ -40,7 +40,6 @@ public class AdminMemberResponse {
                         .map(MemberTeam::getTeam)
                         .map(team -> TeamInfoResponse.builder()
                                 .teamName(team.getTeamName())
-                                .teamPageUrl(team.getTeamPageUrl())
                                 .build())
                         .toList())
                 .role(member.getRole())

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamResponse.java
@@ -18,7 +18,6 @@ public class AdminTeamResponse {
     public static class Team {
         private Long id;
         private String teamName;
-        private String teamPageUrl;
         @Builder.Default
         private List<TeamInfoResponse> subTeams = new ArrayList<>();
     }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/member/TeamInfoResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/member/TeamInfoResponse.java
@@ -13,11 +13,9 @@ import lombok.NoArgsConstructor;
 public class TeamInfoResponse {
     private Long id;
     private String teamName;
-    private String teamPageUrl;
 
     public TeamInfoResponse(Team team) {
         this.id = team.getId();
         this.teamName = team.getTeamName();
-        this.teamPageUrl = team.getTeamPageUrl();
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/Team.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/Team.java
@@ -15,8 +15,8 @@ public class Team {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String teamName;
-    private String teamPageUrl;
 
     @OneToMany(mappedBy = "team")
     @Builder.Default

--- a/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoService.java
@@ -2,9 +2,13 @@ package com.gdsc_knu.official_homepage.service;
 
 import com.gdsc_knu.official_homepage.dto.member.MemberRequest;
 import com.gdsc_knu.official_homepage.dto.member.MemberResponse;
+import com.gdsc_knu.official_homepage.dto.member.TeamInfoResponse;
+
+import java.util.List;
 
 public interface MemberInfoService {
     MemberResponse getMemberInfo(Long id);
     void updateMemberInfo(Long id, MemberRequest.Update memberInfoUpdate);
     void addMemberInfo(Long id, MemberRequest.Append memberInfoAdd);
+    List<TeamInfoResponse> getMemberTeamInfo(Long id);
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
@@ -67,4 +67,13 @@ public class MemberInfoServiceImpl implements MemberInfoService {
                        request.getStudentNumber(),
                        request.getPhoneNumber());
     }
+
+    @Override
+    public List<TeamInfoResponse> getMemberTeamInfo(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND))
+                .getMemberTeams().stream()
+                .map(memberTeam -> new TeamInfoResponse(memberTeam.getTeam()))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
@@ -38,7 +38,6 @@ public class AdminTeamServiceImpl implements AdminTeamService {
                 .map(team -> AdminTeamResponse.Team.builder()
                         .id(team.getId())
                         .teamName(team.getTeamName())
-                        .teamPageUrl(team.getTeamPageUrl())
                         .subTeams(team.getSubTeams().stream()
                                 .map(TeamInfoResponse::new)
                                 .toList())
@@ -59,7 +58,6 @@ public class AdminTeamServiceImpl implements AdminTeamService {
 
         Team newTeam = teamRepository.save(Team.builder()
                 .teamName(teamName)
-                .teamPageUrl(createTeamPageUrl(teamName))
                 .build());
 
         List<Member> members = (track != null)
@@ -91,8 +89,6 @@ public class AdminTeamServiceImpl implements AdminTeamService {
 
         Team newSubTeam = teamRepository.save(Team.builder()
                 .teamName(parentTeam.getTeamName() + " " + (parentTeam.getSubTeams().size() + 1) + "팀")
-                .teamPageUrl(createTeamPageUrl(
-                        parentTeam.getTeamName() + "-" + (parentTeam.getSubTeams().size() + 1 ) + "팀"))
                 .build());
         parentTeam.addSubTeam(newSubTeam);
 
@@ -185,15 +181,5 @@ public class AdminTeamServiceImpl implements AdminTeamService {
         }
         subTeams.remove(subTeams.size() - 1);
         teamRepository.deleteById(deleteSubTeamId);
-    }
-
-    /**
-     * 팀 이름을 기반으로 팀 페이지 url 생성(현재는 임시 url)
-     * @param teamName 팀 이름
-     * @return String 팀 페이지 url
-     */
-    // 임시 url 생성
-    private String createTeamPageUrl(String teamName) {
-        return "www.gdsc-knu.com/" + teamName;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 멤버 소속 팀 리스트 조회 기능 구현 
- 팀 페이지 url 컬럼 및 관련 로직 삭제

## To Reviewers 📢
- 일단 API를 MemberController에 위치 시켰는데, TeamController가 더 적절할 수도 있을 것 같습니다. 의견 부탁드립니다.

## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #102 