### PR TITLE
Fix: id=0 으로 조회할 경우 바로 종료

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/controller/TeamController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/TeamController.java
@@ -26,6 +26,8 @@ public class TeamController {
     @Operation(summary = "팀원 정보 조회 API",
             description = "해당 팀의 팀원목록(유저 ID, 이름, 직렬)을 반환합니다. (미배치된 팀은 조회되지 않습니다.)")
     public ResponseEntity<List<TeamResponse.MemberInfo>> getTeamMembers(@PathVariable("teamId") Long teamId) {
+        if (teamId.equals(0L))
+            return null;
         return ResponseEntity.ok().body(teamService.getTeamMember(teamId));
     }
 

--- a/src/main/java/com/gdsc_knu/official_homepage/service/TeamService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/TeamService.java
@@ -9,6 +9,7 @@ import com.gdsc_knu.official_homepage.repository.MemberTeamRepository;
 import com.gdsc_knu.official_homepage.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -19,6 +20,7 @@ public class TeamService {
     private final MemberTeamRepository memberTeamRepository;
     private final TeamRepository teamRepository;
 
+    @Transactional(readOnly = true)
     public List<TeamResponse.MemberInfo> getTeamMember(Long teamId) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 팀입니다."));


### PR DESCRIPTION
## 🔎 작업 내용
- 팀원 조회 시 id=0 으로 조회할 경우 트랜젝션 시작 전 바로 종료

## To Reviewers 📢


## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- #97 