### PR TITLE
Refac/issue #109

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/memberStatus/AdminMemberResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/memberStatus/AdminMemberResponse.java
@@ -2,7 +2,6 @@ package com.gdsc_knu.official_homepage.dto.admin.memberStatus;
 
 import com.gdsc_knu.official_homepage.dto.member.TeamInfoResponse;
 import com.gdsc_knu.official_homepage.entity.Member;
-import com.gdsc_knu.official_homepage.entity.MemberTeam;
 import com.gdsc_knu.official_homepage.entity.enumeration.Role;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 import lombok.AllArgsConstructor;
@@ -10,7 +9,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -24,8 +22,7 @@ public class AdminMemberResponse {
     private String studentNumber;
     private String email;
     private String phoneNumber;
-    @Builder.Default
-    private List<TeamInfoResponse> teams = new ArrayList<>();
+    private List<TeamInfoResponse> teams;
     private Role role;
 
     public static AdminMemberResponse from(Member member) {
@@ -36,8 +33,7 @@ public class AdminMemberResponse {
                 .studentNumber(member.getStudentNumber())
                 .email(member.getEmail())
                 .phoneNumber(member.getPhoneNumber())
-                .teams(member.getMemberTeams().stream()
-                        .map(MemberTeam::getTeam)
+                .teams(member.getTeams().stream()
                         .map(TeamInfoResponse::new)
                         .toList())
                 .role(member.getRole())

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/memberStatus/AdminMemberResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/memberStatus/AdminMemberResponse.java
@@ -34,7 +34,7 @@ public class AdminMemberResponse {
                 .email(member.getEmail())
                 .phoneNumber(member.getPhoneNumber())
                 .teams(member.getTeams().stream()
-                        .map(TeamInfoResponse::new)
+                        .map(TeamInfoResponse::from)
                         .toList())
                 .role(member.getRole())
                 .build();

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/member/TeamInfoResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/member/TeamInfoResponse.java
@@ -18,4 +18,11 @@ public class TeamInfoResponse {
         this.id = team.getId();
         this.teamName = team.getTeamName();
     }
+
+    public static TeamInfoResponse from(Team team) {
+        return TeamInfoResponse.builder()
+                .id(team.getId())
+                .teamName(team.getTeamName())
+                .build();
+    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/Member.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/Member.java
@@ -63,4 +63,11 @@ public class Member extends BaseTimeEntity{
         this.phoneNumber = phoneNumber;
         this.role = Role.ROLE_GUEST;
     }
+
+    public List<Team> getTeams() {
+        return this.memberTeams.stream()
+                .map(MemberTeam::getTeam)
+                .filter(team -> team.getParent()!=null)
+                .toList();
+    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
@@ -54,7 +54,7 @@ public class MemberInfoServiceImpl implements MemberInfoService {
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND))
                 .getTeams().stream()
                 .sorted(Comparator.comparing(Team::getId).reversed())
-                .map(TeamInfoResponse::new)
+                .map(TeamInfoResponse::from)
                 .toList();
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
@@ -2,7 +2,7 @@ package com.gdsc_knu.official_homepage.service;
 
 import com.gdsc_knu.official_homepage.dto.member.*;
 import com.gdsc_knu.official_homepage.entity.Member;
-import com.gdsc_knu.official_homepage.entity.MemberTeam;
+import com.gdsc_knu.official_homepage.entity.Team;
 import com.gdsc_knu.official_homepage.exception.CustomException;
 import com.gdsc_knu.official_homepage.exception.ErrorCode;
 import com.gdsc_knu.official_homepage.repository.MemberRepository;
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,12 +24,11 @@ public class MemberInfoServiceImpl implements MemberInfoService {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 
-        List<TeamInfoResponse> teamInfos = member.getMemberTeams().stream()
-                .filter(memberTeam -> memberTeam.getTeam().getParent() != null)
-                .map(memberTeam -> new TeamInfoResponse(memberTeam.getTeam()))
-                .collect(Collectors.toList());
+        List<TeamInfoResponse> teams = member.getTeams().stream()
+                .map(TeamInfoResponse::from)
+                .toList();
 
-        return new MemberResponse(member,teamInfos);
+        return new MemberResponse(member,teams);
     }
 
     @Transactional
@@ -54,10 +52,9 @@ public class MemberInfoServiceImpl implements MemberInfoService {
     public List<TeamInfoResponse> getMemberTeamInfo(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND))
-                .getMemberTeams().stream()
-                .filter(memberTeam -> memberTeam.getTeam().getParent() != null)
-                .sorted(Comparator.comparing(MemberTeam::getId).reversed())
-                .map(memberTeam -> new TeamInfoResponse(memberTeam.getTeam()))
-                .collect(Collectors.toList());
+                .getTeams().stream()
+                .sorted(Comparator.comparing(Team::getId).reversed())
+                .map(TeamInfoResponse::new)
+                .toList();
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 부모팀 체크 공통 로직을 추출하여 반복되는 실수를 방지한다.
  - member 엔티티에 배정이 완료된 team만 조회하는 getter 메소드를 정의한다
  - 외부에서는 정의한 getter 로 team정보에 접근한다.

## To Reviewers 📢


## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #109 