### PR TITLE
테크블로그 엔티티 작성

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
@@ -1,0 +1,39 @@
+package com.gdsc_knu.official_homepage.entity.post;
+
+
+import com.gdsc_knu.official_homepage.entity.BaseTimeEntity;
+import com.gdsc_knu.official_homepage.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
+
+    @Column(length = 4000)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member author;
+
+    // 작성자 비정규화
+    private String authorName;
+    @Column(length = 500)
+    private String authorProfile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Comment parent;
+
+
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/Post.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/Post.java
@@ -1,0 +1,46 @@
+package com.gdsc_knu.official_homepage.entity.post;
+
+import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.entity.post.enumeration.Category;
+import com.gdsc_knu.official_homepage.entity.post.enumeration.PostStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Comment> commentList = new ArrayList<>();
+
+    private String title;
+
+    @Column(length = 65535)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    private String thumbnailUrl;
+
+    private Category category;
+
+    private PostStatus status;
+
+    private int likeCount;
+    private int commentCount;
+    private int sharedCount;
+
+    private LocalDateTime publishedAt;
+    private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/enumeration/Category.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/enumeration/Category.java
@@ -1,0 +1,5 @@
+package com.gdsc_knu.official_homepage.entity.post.enumeration;
+
+public enum Category {
+    BACKEND, FRONTEND, ANDROID, AI, DESIGN, ETC
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/enumeration/PostStatus.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/enumeration/PostStatus.java
@@ -1,0 +1,6 @@
+package com.gdsc_knu.official_homepage.entity.post.enumeration;
+
+public enum PostStatus {
+    // 임시 저장 , 저장
+    TEMPORAL, SAVED
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 게시글 엔티티 작성
- 댓글 엔티티 작성

## To Reviewers 📢
- ui 에 게시글 작성자가 없어서 게시글에는 작성자 관련된 비정규화를 하지 않았는데, 작성자 정보가 필요하면 해당 필드는 post엔티티에 중복으로 두는 것도 join을 줄이기 위해 좋을 것 같습니다.
- 좋아요 기능이 일단 우선 순위가 낮다고 판단하여 정수형의 likeCount 필드만 뒀는데, 좋아요 기능 구현할 때 사용자와 매치하기 위한 테이블이 추가로 필요할 것 같습니다.
- 게시글은 좋아요, 댓글 수 등등으로 수정될 수 있고, 최초로 레코드가 생긴시점이 출간일자가 되는게 아니라 상태가 'SAVED'로 바뀌는 순간이 출간일자가 되기 때문에 BaseTimeEntity를 상속하지 않았습니다.

## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #116 