### PR TITLE
게시글 댓글 CRUD

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -13,7 +13,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+      checks: write
+    
 
     # set up java
     steps:

--- a/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.gdsc_knu.official_homepage.authentication.jwt.JwtValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -29,7 +30,7 @@ public class SecurityConfig {
 
 
     private static final String[] WHITE_LIST = {
-            "/**",
+            "/api/post/{postId:\\d+}/comment/**"
     };
     private static final String[] MEMBER_AUTHENTICATION_LIST = {
 
@@ -53,6 +54,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(authorizeRequest -> authorizeRequest
                         .requestMatchers(CORE_AUTHENTICATION_LIST).hasRole("CORE")
+                        .requestMatchers(HttpMethod.GET, WHITE_LIST).permitAll()
                         .anyRequest().permitAll()
                 );
 

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
@@ -1,0 +1,31 @@
+package com.gdsc_knu.official_homepage.controller.post;
+
+import com.gdsc_knu.official_homepage.annotation.TokenMember;
+import com.gdsc_knu.official_homepage.authentication.jwt.JwtMemberDetail;
+import com.gdsc_knu.official_homepage.dto.post.CommentRequest;
+import com.gdsc_knu.official_homepage.service.post.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Comment", description = "게시글 댓글 관련 API")
+@RestController
+@RequestMapping("/api/post")
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+    @PostMapping("{postId}/comment")
+    @Operation(summary = "댓글 작성 API", description = "parentId가 null or 0이면 댓글, 아니면 해당 댓글의 답글로 저장한다.")
+    public ResponseEntity<Void> createComment(
+            @TokenMember JwtMemberDetail jwtMemberDetail,
+            @PathVariable(name = "postId")Long postId,
+            @RequestBody CommentRequest.Create request
+    ) {
+        commentService.createComment(jwtMemberDetail.getId(), postId, request);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
@@ -62,5 +62,16 @@ public class CommentController {
     }
 
 
+    @PatchMapping("comment/{commentId}")
+    @Operation(summary = "댓글 삭제 API",
+            description = "게시글 작성자, 댓글 작성자만이 댓글을 삭제할 수 있다. \n\n 부모 댓글 삭제 시 자식 댓글 모두 삭제된다.")
+    public ResponseEntity<Void> deleteComment(
+            @TokenMember JwtMemberDetail jwtMemberDetail,
+            @PathVariable(name = "commentId")Long commentId)
+    {
+        commentService.deleteComment(jwtMemberDetail.getId(), commentId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
 
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
     private final CommentService commentService;
     @PostMapping("{postId}/comment")
-    @Operation(summary = "댓글 작성 API", description = "parentId가 null or 0이면 댓글, 아니면 해당 댓글의 답글로 저장한다.")
+    @Operation(summary = "댓글 작성 API", description = "groupId가 null or 0이면 댓글, 아니면 해당 댓글의 답글로 저장한다.")
     public ResponseEntity<Void> createComment(
             @TokenMember JwtMemberDetail jwtMemberDetail,
             @PathVariable(name = "postId")Long postId,

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
@@ -2,13 +2,17 @@ package com.gdsc_knu.official_homepage.controller.post;
 
 import com.gdsc_knu.official_homepage.annotation.TokenMember;
 import com.gdsc_knu.official_homepage.authentication.jwt.JwtMemberDetail;
+import com.gdsc_knu.official_homepage.dto.PagingResponse;
 import com.gdsc_knu.official_homepage.dto.post.CommentRequest;
+import com.gdsc_knu.official_homepage.dto.post.CommentResponse;
 import com.gdsc_knu.official_homepage.service.post.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Comment", description = "게시글 댓글 관련 API")
@@ -22,10 +26,29 @@ public class CommentController {
     public ResponseEntity<Void> createComment(
             @TokenMember JwtMemberDetail jwtMemberDetail,
             @PathVariable(name = "postId")Long postId,
-            @RequestBody CommentRequest.Create request
-    ) {
+            @RequestBody CommentRequest.Create request)
+    {
         commentService.createComment(jwtMemberDetail.getId(), postId, request);
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
+
+    @GetMapping("{postId}/comment")
+    @Operation(summary = "댓글 조회 API", description = "댓글의 답글까지 포함한 개수로 페이징 조회한다.")
+    public ResponseEntity<PagingResponse<CommentResponse>> getComment(
+            Authentication authentication,
+            @PathVariable(name = "postId")Long postId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "5") int size)
+    {
+        Long memberId = 0L;
+        if (authentication != null){
+            JwtMemberDetail jwtMemberDetail = (JwtMemberDetail) authentication.getPrincipal();
+            memberId = jwtMemberDetail.getId();
+        }
+        return ResponseEntity.ok().body(commentService.getComment(memberId, postId, PageRequest.of(page,size)));
+    }
+
+
 
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
@@ -50,5 +50,17 @@ public class CommentController {
     }
 
 
+    @PatchMapping("comment/{commentId}")
+    @Operation(summary = "댓글 수정 API", description = "댓글 작성자만이 본인의 댓글을 수정할 수 있다.")
+    public ResponseEntity<Void> updateComment(
+            @TokenMember JwtMemberDetail jwtMemberDetail,
+            @PathVariable(name = "commentId")Long commentId,
+            @RequestBody CommentRequest.Update request)
+    {
+        commentService.updateComment(jwtMemberDetail.getId(), commentId, request);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+
 
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/post/CommentController.java
@@ -62,7 +62,7 @@ public class CommentController {
     }
 
 
-    @PatchMapping("comment/{commentId}")
+    @DeleteMapping("comment/{commentId}")
     @Operation(summary = "댓글 삭제 API",
             description = "게시글 작성자, 댓글 작성자만이 댓글을 삭제할 수 있다. \n\n 부모 댓글 삭제 시 자식 댓글 모두 삭제된다.")
     public ResponseEntity<Void> deleteComment(

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/PagingResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/PagingResponse.java
@@ -1,5 +1,6 @@
 package com.gdsc_knu.official_homepage.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,9 +15,11 @@ import java.util.function.Function;
 @AllArgsConstructor
 public class PagingResponse<T> {
     private final List<T> data;
-    private final int page;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final Integer page;
     private final boolean hasNext;
-    private final int totalPage;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final Integer totalPage;
 
 
 
@@ -26,6 +29,15 @@ public class PagingResponse<T> {
                 .page(data.getNumber())
                 .hasNext(data.hasNext())
                 .totalPage(data.getTotalPages())
+                .build();
+    }
+
+    public static <U,T> PagingResponse<T> withoutCountFrom(Page<U> data, int size, Function<U,T> converter) {
+        boolean hasNext = data.getNumberOfElements() >= size;
+
+        return PagingResponse.<T>builder()
+                .data(data.getContent().stream().map(converter).toList())
+                .hasNext(hasNext)
                 .build();
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/post/AccessModel.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/post/AccessModel.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 
 @Builder
 @AllArgsConstructor
-public class PermissionModel {
+public class AccessModel {
     @JsonProperty(value = "canDelete")
     private boolean delete;
     private boolean modify;
@@ -19,8 +19,8 @@ public class PermissionModel {
         return modify;
     }
 
-    public static PermissionModel of(boolean canDelete, boolean canModify) {
-        return PermissionModel.builder()
+    public static AccessModel of(boolean canDelete, boolean canModify) {
+        return AccessModel.builder()
                 .delete(canDelete)
                 .modify(canModify)
                 .build();

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentRequest.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentRequest.java
@@ -15,4 +15,12 @@ public class CommentRequest {
         @NotBlank(message = "내용을 입력해주세요")
         private String content;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Update {
+        @NotBlank(message = "내용을 입력해주세요")
+        private String content;
+    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentRequest.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentRequest.java
@@ -10,7 +10,7 @@ public class CommentRequest {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Create {
-        private Long parentId;
+        private Long groupId;
 
         @NotBlank(message = "내용을 입력해주세요")
         private String content;

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentRequest.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentRequest.java
@@ -1,0 +1,18 @@
+package com.gdsc_knu.official_homepage.dto.post;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CommentRequest {
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Create {
+        private Long parentId;
+
+        @NotBlank(message = "내용을 입력해주세요")
+        private String content;
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentResponse.java
@@ -1,0 +1,49 @@
+package com.gdsc_knu.official_homepage.dto.post;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.gdsc_knu.official_homepage.entity.post.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CommentResponse {
+    private Long id;
+    private String content;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime createAt;
+
+    private String name;
+    private String profileUrl;
+
+    @JsonProperty(value = "isChild")
+    private boolean isChild;
+    private boolean canDelete;
+    private boolean canModify;
+
+    public static CommentResponse from(Comment comment, PermissionModel permission){
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .createAt(comment.getCreateAt())
+                .name(comment.getAuthorName())
+                .profileUrl(comment.getAuthorProfile())
+                .isChild(comment.getParent() != null)
+                .canDelete(permission.canDelete())
+                .canModify(permission.canModify())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentResponse.java
@@ -27,8 +27,7 @@ public class CommentResponse {
     private String name;
     private String profileUrl;
 
-    @JsonProperty(value = "isChild")
-    private boolean isChild;
+    private Boolean isChild;
     private boolean canDelete;
     private boolean canModify;
 
@@ -39,7 +38,7 @@ public class CommentResponse {
                 .createAt(comment.getCreateAt())
                 .name(comment.getAuthorName())
                 .profileUrl(comment.getAuthorProfile())
-                .isChild(comment.getParent() != null)
+                .isChild(comment.isChild())
                 .canDelete(access.canDelete())
                 .canModify(access.canModify())
                 .build();

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/post/CommentResponse.java
@@ -32,7 +32,7 @@ public class CommentResponse {
     private boolean canDelete;
     private boolean canModify;
 
-    public static CommentResponse from(Comment comment, PermissionModel permission){
+    public static CommentResponse from(Comment comment, AccessModel access){
         return CommentResponse.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
@@ -40,8 +40,8 @@ public class CommentResponse {
                 .name(comment.getAuthorName())
                 .profileUrl(comment.getAuthorProfile())
                 .isChild(comment.getParent() != null)
-                .canDelete(permission.canDelete())
-                .canModify(permission.canModify())
+                .canDelete(access.canDelete())
+                .canModify(access.canModify())
                 .build();
     }
 

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/post/PermissionModel.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/post/PermissionModel.java
@@ -1,0 +1,28 @@
+package com.gdsc_knu.official_homepage.dto.post;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Builder
+@AllArgsConstructor
+public class PermissionModel {
+    @JsonProperty(value = "canDelete")
+    private boolean delete;
+    private boolean modify;
+
+    public boolean canDelete() {
+        return delete;
+    }
+
+    public boolean canModify() {
+        return modify;
+    }
+
+    public static PermissionModel of(boolean canDelete, boolean canModify) {
+        return PermissionModel.builder()
+                .delete(canDelete)
+                .modify(canModify)
+                .build();
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
@@ -41,7 +41,7 @@ public class Comment extends BaseTimeEntity {
     private Comment parent;
 
     @Builder.Default
-    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> replies = new ArrayList<>();
 
     public Comment(Post post, String content, Member author, Comment parent) {

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
@@ -10,6 +10,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -37,15 +40,19 @@ public class Comment extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Comment parent;
 
-    public static Comment create(Post post, String content, Member member, Comment parent) {
-        return Comment.builder()
-                .post(post)
-                .content(content)
-                .author(member)
-                .authorName(member.getName())
-                .authorProfile(member.getProfileUrl())
-                .parent(parent)
-                .build();
+    @Builder.Default
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Comment> replies = new ArrayList<>();
+
+    public Comment(Post post, String content, Member author, Comment parent) {
+        this.post = post;
+        this.content = content;
+        this.author = author;
+        this.authorName = author.getName();
+        this.authorProfile = author.getProfileUrl();
+        this.parent = parent != null
+                ? parent
+                : this;
     }
 
 

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
@@ -59,5 +59,10 @@ public class Comment extends BaseTimeEntity {
         this.content = content;
     }
 
+    public boolean isChild(){
+        // 프로퍼티 접근
+        return !this.parent.getId().equals(this.id);
+    }
+
 
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
@@ -55,5 +55,9 @@ public class Comment extends BaseTimeEntity {
                 : this;
     }
 
+    public void update(String content) {
+        this.content = content;
+    }
+
 
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
@@ -8,9 +8,11 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Builder;
 
 @Entity
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseTimeEntity {
@@ -34,6 +36,17 @@ public class Comment extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Comment parent;
+
+    public static Comment create(Post post, String content, Member member, Comment parent) {
+        return Comment.builder()
+                .post(post)
+                .content(content)
+                .author(member)
+                .authorName(member.getName())
+                .authorProfile(member.getProfileUrl())
+                .parent(parent)
+                .build();
+    }
 
 
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/Comment.java
@@ -44,15 +44,16 @@ public class Comment extends BaseTimeEntity {
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> replies = new ArrayList<>();
 
-    public Comment(Post post, String content, Member author, Comment parent) {
-        this.post = post;
-        this.content = content;
-        this.author = author;
-        this.authorName = author.getName();
-        this.authorProfile = author.getProfileUrl();
-        this.parent = parent != null
-                ? parent
-                : this;
+    public static Comment from(String content, Member author, Post post, Comment parent) {
+        Comment comment = Comment.builder()
+                .post(post)
+                .content(content)
+                .author(author)
+                .authorName(author.getName())
+                .authorProfile(author.getProfileUrl())
+                .build();
+        comment.parent = (parent == null) ? comment : parent;
+        return comment;
     }
 
     public void update(String content) {

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/Post.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/Post.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
@@ -19,6 +20,7 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Builder.Default
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     List<Comment> commentList = new ArrayList<>();
 

--- a/src/main/java/com/gdsc_knu/official_homepage/exception/ErrorCode.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
 
     // Comment
     COMMENT_NOT_FOUND(404, HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    COMMENT_FORBIDDEN(403, HttpStatus.FORBIDDEN, "댓글을 수정할 수 있는 권한이 없습니다."),
 
     // Server error
     FAILED_UPLOAD(500, HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),

--- a/src/main/java/com/gdsc_knu/official_homepage/exception/ErrorCode.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     // Comment
     COMMENT_NOT_FOUND(404, HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     COMMENT_FORBIDDEN(403, HttpStatus.FORBIDDEN, "댓글을 수정할 수 있는 권한이 없습니다."),
+    INVALID_COMMENT(400, HttpStatus.BAD_REQUEST, "상위 댓글에만 답글을 남길 수 있습니다."),
 
     // Server error
     FAILED_UPLOAD(500, HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),

--- a/src/main/java/com/gdsc_knu/official_homepage/exception/ErrorCode.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/exception/ErrorCode.java
@@ -33,6 +33,12 @@ public enum ErrorCode {
 
     INVALID_INPUT(400, HttpStatus.BAD_REQUEST,"잘못된 요청입니다."),
 
+    // Post
+    POST_NOT_FOUND(404, HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+
+    // Comment
+    COMMENT_NOT_FOUND(404, HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+
     // Server error
     FAILED_UPLOAD(500, HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     FAILED_SEND_MAIL(500, HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.");

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/CommentRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/CommentRepository.java
@@ -1,7 +1,15 @@
 package com.gdsc_knu.official_homepage.repository;
 
 import com.gdsc_knu.official_homepage.entity.post.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("SELECT c " +
+            "FROM Comment c " +
+            "WHERE c.post.id = :postId "+
+            "ORDER BY c.parent.id ASC, c.createAt ASC")
+    Page<Comment> findCommentAndReply(Pageable pageable, Long postId);
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/CommentRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.gdsc_knu.official_homepage.repository;
+
+import com.gdsc_knu.official_homepage.entity.post.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/PostRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.gdsc_knu.official_homepage.repository;
+
+import com.gdsc_knu.official_homepage.entity.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/service/post/CommentService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/post/CommentService.java
@@ -1,0 +1,45 @@
+package com.gdsc_knu.official_homepage.service.post;
+
+import com.gdsc_knu.official_homepage.dto.post.CommentRequest;
+import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.entity.post.Comment;
+import com.gdsc_knu.official_homepage.entity.post.Post;
+import com.gdsc_knu.official_homepage.exception.CustomException;
+import com.gdsc_knu.official_homepage.exception.ErrorCode;
+import com.gdsc_knu.official_homepage.repository.CommentRepository;
+import com.gdsc_knu.official_homepage.repository.MemberRepository;
+import com.gdsc_knu.official_homepage.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void createComment(Long memberId, Long postId, CommentRequest.Create request){
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Comment parent = getParentComment(request.getParentId());
+        Comment comment = Comment.create(post, request.getContent(), member, parent);
+
+        commentRepository.save(comment);
+    }
+
+    private Comment getParentComment(Long parentId) {
+        if (parentId != null && parentId != 0) {
+            return commentRepository.findById(parentId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+        }
+        return null;
+    }
+
+
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/service/post/CommentService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/post/CommentService.java
@@ -71,14 +71,22 @@ public class CommentService {
 
     @Transactional
     public void updateComment(Long memberId, Long commentId, CommentRequest.Update request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
 
-        if (!member.equals(comment.getAuthor())) {
-            throw new CustomException(ErrorCode.COMMENT_NOT_FOUND);
+        if (!comment.getAuthor().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.COMMENT_FORBIDDEN);
         }
         comment.update(request.getContent());
+    }
+
+    @Transactional
+    public void deleteComment(Long memberId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+        if (!comment.getAuthor().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.COMMENT_FORBIDDEN);
+        }
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/post/CommentService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/post/CommentService.java
@@ -32,7 +32,7 @@ public class CommentService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        Comment parent = getParentComment(request.getParentId());
+        Comment parent = getParentComment(request.getGroupId());
         Comment comment = new Comment(post, request.getContent(), member, parent);
         commentRepository.save(comment);
     }
@@ -60,13 +60,13 @@ public class CommentService {
         int size = pageRequest.getPageSize();
         return PagingResponse.withoutCountFrom(commentPage, size, comment -> {
             Long commentAuthorId = comment.getAuthor().getId();
-            AccessModel access = validateAccess(memberId, postAuthorId, commentAuthorId);
+            AccessModel access = getAccess(memberId, postAuthorId, commentAuthorId);
             return CommentResponse.from(comment, access);
         });
     }
 
     // post 조회에서도 해당 메서드가 사용될 수 있을 것 같아 protected 로 설정
-    protected AccessModel validateAccess(Long memberId, Long postAuthorId, Long commentAuthorId) {
+    protected AccessModel getAccess(Long memberId, Long postAuthorId, Long commentAuthorId) {
         boolean canDelete = memberId.equals(postAuthorId) || memberId.equals(commentAuthorId);
         boolean canModify = memberId.equals(commentAuthorId);
         return AccessModel.of(canDelete, canModify);

--- a/src/main/java/com/gdsc_knu/official_homepage/service/post/CommentService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/post/CommentService.java
@@ -61,11 +61,24 @@ public class CommentService {
         });
     }
 
-
     // post 조회에서도 해당 메서드가 사용될 수 있을 것 같아 protected 로 설정
     protected AccessModel validateAccess(Long memberId, Long postAuthorId, Long commentAuthorId) {
         boolean canDelete = memberId.equals(postAuthorId) || memberId.equals(commentAuthorId);
         boolean canModify = memberId.equals(commentAuthorId);
         return AccessModel.of(canDelete, canModify);
+    }
+
+
+    @Transactional
+    public void updateComment(Long memberId, Long commentId, CommentRequest.Update request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!member.equals(comment.getAuthor())) {
+            throw new CustomException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+        comment.update(request.getContent());
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/post/CommentService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/post/CommentService.java
@@ -33,7 +33,7 @@ public class CommentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         Comment parent = getParentComment(request.getGroupId());
-        Comment comment = new Comment(post, request.getContent(), member, parent);
+        Comment comment = Comment.from(request.getContent(), member, post, parent);
         commentRepository.save(comment);
     }
 

--- a/src/test/java/com/gdsc_knu/official_homepage/service/post/CommentServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/service/post/CommentServiceTest.java
@@ -1,6 +1,8 @@
 package com.gdsc_knu.official_homepage.service.post;
 
+import com.gdsc_knu.official_homepage.dto.PagingResponse;
 import com.gdsc_knu.official_homepage.dto.post.CommentRequest;
+import com.gdsc_knu.official_homepage.dto.post.CommentResponse;
 import com.gdsc_knu.official_homepage.entity.Member;
 import com.gdsc_knu.official_homepage.entity.post.Comment;
 import com.gdsc_knu.official_homepage.entity.post.Post;
@@ -15,11 +17,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
+import java.util.Collections;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 
@@ -30,40 +34,77 @@ class CommentServiceTest {
     @Mock private PostRepository postRepository;
     @Mock private MemberRepository memberRepository;
 
-
     private final Long memberId = 1L;
     private final Long postId = 1L;
+    private final Long postAuthorId = 2L;
+    private final Long commentAuthorId = 3L;
 
     @Test
     @DisplayName("댓글이 정상적으로 저장된다")
-    void createComment() {
+    void saveComment() {
         // given
         when(postRepository.findById(postId)).thenReturn(createPost());
-        when(memberRepository.findById(memberId)).thenReturn(createAuthor());
-
+        when(memberRepository.findById(memberId)).thenReturn(createAuthor(memberId));
         // when
         commentService.createComment(memberId, postId, new CommentRequest.Create(null, "댓글 내용"));
-
         // then
         verify(commentRepository, times(1)).save(any(Comment.class));
     }
 
     @Test
     @DisplayName("존재하지 않는 댓글에 답글을 남기면 오류를 발생시킨다.")
-    void createCommentInvalidParent() {
+    void saveCommentInvalidParent() {
         // given
         when(postRepository.findById(postId)).thenReturn(createPost());
-        when(memberRepository.findById(memberId)).thenReturn(createAuthor());
-
+        when(memberRepository.findById(memberId)).thenReturn(createAuthor(memberId));
         // when
         Long fakeParentId = 1L;
-
         Exception exception = assertThrows(CustomException.class, () ->
             commentService.createComment(memberId, postId, new CommentRequest.Create(fakeParentId, "댓글 내용"))
         );
-
         //then
         assertEquals(ErrorCode.COMMENT_NOT_FOUND.getMessage(), exception.getMessage());
+    }
+
+    //TODO: 통합테스트
+    @Test
+    @DisplayName("댓글의 순서가 올바르게 조회된다")
+    void getComment() {
+
+    }
+
+    @Test
+    @DisplayName("댓글 작성자는 본인이 작성한 댓글을 수정, 삭제할 수 있다.")
+    void getCommentByCommentAuthor() {
+        // given
+        long commentAuthorId = memberId;
+        when(postRepository.findById(postId)).thenReturn(createPostWithAuthor(postAuthorId));
+        Comment comment = createComment(commentAuthorId);
+        when(commentRepository.findCommentAndReply(PageRequest.of(0,5), postId))
+                .thenReturn(new PageImpl<>(Collections.singletonList(comment)));
+        // when
+        PagingResponse<CommentResponse> response = commentService.getComment(memberId, postId, PageRequest.of(0,5));
+
+        // then
+        assertTrue(response.getData().get(0).isCanModify());
+        assertTrue(response.getData().get(0).isCanDelete());
+    }
+
+    @Test
+    @DisplayName("게시글 작성자는 해당 게시글의 댓글을 삭제할 수 있고, 수정할 수 없다.")
+    void getCommentByPostAuthor() {
+        //given
+        long postAuthorId = memberId;
+        when(postRepository.findById(postId)).thenReturn(createPostWithAuthor(postAuthorId));
+        Comment comment = createComment(commentAuthorId);
+        when(commentRepository.findCommentAndReply(PageRequest.of(0,5), postId))
+                .thenReturn(new PageImpl<>(Collections.singletonList(comment)));
+        // when
+        PagingResponse<CommentResponse> response = commentService.getComment(memberId, postId, PageRequest.of(0,5));
+
+        // then
+        assertFalse(response.getData().get(0).isCanModify());
+        assertTrue(response.getData().get(0).isCanDelete());
     }
 
 
@@ -78,9 +119,26 @@ class CommentServiceTest {
                 .build());
     }
 
-    public Optional<Member> createAuthor() {
+    public Optional<Post> createPostWithAuthor(long authorId) {
+        Member member = createAuthor(authorId).get();
+        return Optional.ofNullable(Post.builder()
+                .id(postId)
+                .member(member)
+                .build());
+    }
+
+    public Comment createComment(long authorId) {
+        Member author = createAuthor(authorId).get();
+        return Comment.builder()
+                .id(postId)
+                .content("댓글")
+                .author(author)
+                .build();
+    }
+
+    public Optional<Member> createAuthor(long id) {
         return Optional.ofNullable(Member.builder()
-                .id(memberId)
+                .id(id)
                 .email("email@email.com")
                 .phoneNumber("010-0000-0000")
                 .name("테스트 유저")

--- a/src/test/java/com/gdsc_knu/official_homepage/service/post/CommentServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/service/post/CommentServiceTest.java
@@ -1,0 +1,90 @@
+package com.gdsc_knu.official_homepage.service.post;
+
+import com.gdsc_knu.official_homepage.dto.post.CommentRequest;
+import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.entity.post.Comment;
+import com.gdsc_knu.official_homepage.entity.post.Post;
+import com.gdsc_knu.official_homepage.exception.CustomException;
+import com.gdsc_knu.official_homepage.exception.ErrorCode;
+import com.gdsc_knu.official_homepage.repository.CommentRepository;
+import com.gdsc_knu.official_homepage.repository.MemberRepository;
+import com.gdsc_knu.official_homepage.repository.PostRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+    @InjectMocks private CommentService commentService;
+    @Mock private CommentRepository commentRepository;
+    @Mock private PostRepository postRepository;
+    @Mock private MemberRepository memberRepository;
+
+
+    private final Long memberId = 1L;
+    private final Long postId = 1L;
+
+    @Test
+    @DisplayName("댓글이 정상적으로 저장된다")
+    void createComment() {
+        // given
+        when(postRepository.findById(postId)).thenReturn(createPost());
+        when(memberRepository.findById(memberId)).thenReturn(createAuthor());
+
+        // when
+        commentService.createComment(memberId, postId, new CommentRequest.Create(null, "댓글 내용"));
+
+        // then
+        verify(commentRepository, times(1)).save(any(Comment.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글에 답글을 남기면 오류를 발생시킨다.")
+    void createCommentInvalidParent() {
+        // given
+        when(postRepository.findById(postId)).thenReturn(createPost());
+        when(memberRepository.findById(memberId)).thenReturn(createAuthor());
+
+        // when
+        Long fakeParentId = 1L;
+
+        Exception exception = assertThrows(CustomException.class, () ->
+            commentService.createComment(memberId, postId, new CommentRequest.Create(fakeParentId, "댓글 내용"))
+        );
+
+        //then
+        assertEquals(ErrorCode.COMMENT_NOT_FOUND.getMessage(), exception.getMessage());
+    }
+
+
+
+
+
+
+
+    public Optional<Post> createPost() {
+        return Optional.ofNullable(Post.builder()
+                .id(postId)
+                .build());
+    }
+
+    public Optional<Member> createAuthor() {
+        return Optional.ofNullable(Member.builder()
+                .id(memberId)
+                .email("email@email.com")
+                .phoneNumber("010-0000-0000")
+                .name("테스트 유저")
+                .profileUrl("image.png")
+                .build());
+    }
+}

--- a/src/test/java/com/gdsc_knu/official_homepage/service/post/CommentServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/service/post/CommentServiceTest.java
@@ -133,6 +133,13 @@ class CommentServiceTest {
                 .id(postId)
                 .content("댓글")
                 .author(author)
+                .parent(fakeParentComment())
+                .build();
+    }
+
+    public Comment fakeParentComment() {
+        return Comment.builder()
+                .id(1L)
                 .build();
     }
 


### PR DESCRIPTION
## 🔎 작업 내용
- 댓글 작성, 조회, 수정, 삭제

## To Reviewers 📢
- 게시글 조회 관련 api는 WHITE LIST에 등록하여 로그인없이 조회할 수 있도록 하였습니다.
  - 이때 수정, 삭제 권한을 함께 알려줘야 해서 로그인하지 않은 사용자에 대해서는 id=0을 임시로 부여하였는데 id 생성방식에 종속적이게 되는 것 같아 좋은 설계는 아니라고 생각합니다. 
  - 해당 메서드를 인터페이스로 만들고 로그인 여부에 따라 구현체를 달리할 계획이긴 한데, 우선 프론트개발을 위해 지금 상태에서 PR 올립니다
  - 외에도 다른 좋은 방법이 있다면 알려주세요 !
- 페이징 처리할때 무한스크롤의 경우 현재 페이지와 전체 페이지 수를 계산할 필요가 없다고 판단하여 `withoutCountFrom`이라는 메서드를 만들었습니다. 

## 체크 리스트
- [x] 테스트를 작성했습니다.
- [x] 테스트를 통과했습니다.
- [x] API 변경사항이 존재합니다.
- [x] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [x] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #118 