### PR TITLE
Feat/issue #120

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/OfficialHomepageApplication.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/OfficialHomepageApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableCaching
+@EnableScheduling
 public class OfficialHomepageApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/gdsc_knu/official_homepage/OfficialHomepageApplication.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/OfficialHomepageApplication.java
@@ -2,10 +2,12 @@ package com.gdsc_knu.official_homepage;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class OfficialHomepageApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
 
 
     private static final String[] WHITE_LIST = {
-            "/api/post/{postId:\\d+}/comment/**"
+            "/api/post/{postId:\\d+}/comment/**",
+            "/api/post/trending"
     };
     private static final String[] MEMBER_AUTHENTICATION_LIST = {
 

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/post/PostController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/post/PostController.java
@@ -1,0 +1,32 @@
+package com.gdsc_knu.official_homepage.controller.post;
+
+import com.gdsc_knu.official_homepage.dto.post.PostResponse;
+import com.gdsc_knu.official_homepage.entity.post.enumeration.Category;
+import com.gdsc_knu.official_homepage.service.post.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Post", description = "테크블로그 관련 API")
+@RestController
+@RequestMapping("/api/post")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+    @GetMapping("trending")
+    @Operation(summary = "카테고리별 인기글 5개 조회", description = "category가 null이면 전제를 조회한다.")
+    public ResponseEntity<List<PostResponse.Main>> getTrendingPosts(
+            @RequestParam(value = "category", required = false) Category category,
+            @RequestParam(value = "size", defaultValue = "5") int size)
+    {
+        return ResponseEntity.ok().body(postService.getTrendingPosts(category, size));
+    }
+
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/post/PostResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/post/PostResponse.java
@@ -1,0 +1,38 @@
+package com.gdsc_knu.official_homepage.dto.post;
+
+import com.gdsc_knu.official_homepage.entity.post.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class PostResponse {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Main {
+        private Long id;
+        private String title;
+        private String summary;
+        private String thumbnailUrl;
+        private String category;
+        private LocalDateTime createAt;
+        private int likeCount;
+        private int commentCount;
+
+        public static Main from(Post post) {
+            return Main.builder()
+                    .id(post.getId())
+                    .title(post.getTitle())
+                    .summary(post.getContent().substring(0,20))
+                    .thumbnailUrl(post.getThumbnailUrl())
+                    .category(post.getCategory().name())
+                    .createAt(post.getPublishedAt())
+                    .likeCount(post.getLikeCount())
+                    .commentCount(post.getCommentCount())
+                    .build();
+
+        }
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/post/PostResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/post/PostResponse.java
@@ -1,31 +1,41 @@
 package com.gdsc_knu.official_homepage.dto.post;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.gdsc_knu.official_homepage.entity.post.Post;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public class PostResponse {
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class Main {
+    public static class Main implements Serializable{
         private Long id;
         private String title;
         private String summary;
         private String thumbnailUrl;
         private String category;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
         private LocalDateTime createAt;
         private int likeCount;
         private int commentCount;
 
         public static Main from(Post post) {
+            int length = Math.min(post.getContent().length(), 20);
             return Main.builder()
                     .id(post.getId())
                     .title(post.getTitle())
-                    .summary(post.getContent().substring(0,20))
+                    .summary(post.getContent().substring(0,length))
                     .thumbnailUrl(post.getThumbnailUrl())
                     .category(post.getCategory().name())
                     .createAt(post.getPublishedAt())

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/post/Post.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/post/Post.java
@@ -34,8 +34,10 @@ public class Post {
 
     private String thumbnailUrl;
 
+    @Enumerated(EnumType.STRING)
     private Category category;
 
+    @Enumerated(EnumType.STRING)
     private PostStatus status;
 
     private int likeCount;

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/PostQueryFactory.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/PostQueryFactory.java
@@ -1,0 +1,10 @@
+package com.gdsc_knu.official_homepage.repository;
+
+import com.gdsc_knu.official_homepage.entity.post.Post;
+import com.gdsc_knu.official_homepage.entity.post.enumeration.Category;
+
+import java.util.List;
+
+public interface PostQueryFactory {
+    List<Post> findTop5ByCategory(Category category, int size);
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/PostQueryFactoryImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/PostQueryFactoryImpl.java
@@ -1,0 +1,32 @@
+package com.gdsc_knu.official_homepage.repository;
+
+import com.gdsc_knu.official_homepage.entity.post.Post;
+import com.gdsc_knu.official_homepage.entity.post.QPost;
+import com.gdsc_knu.official_homepage.entity.post.enumeration.Category;
+import com.gdsc_knu.official_homepage.entity.post.enumeration.PostStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PostQueryFactoryImpl implements PostQueryFactory{
+    private final JPAQueryFactory jpaQueryFactory;
+    @Override
+    public List<Post> findTop5ByCategory(Category category, int size) {
+        return jpaQueryFactory
+                .selectFrom(QPost.post)
+                .where(QPost.post.status.eq(PostStatus.SAVED)
+                        .and(eqCategory(category)))
+                .orderBy(QPost.post.likeCount.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    private BooleanExpression eqCategory(Category category) {
+        return category == null ? null : QPost.post.category.eq(category);
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/PostRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/PostRepository.java
@@ -3,5 +3,5 @@ package com.gdsc_knu.official_homepage.repository;
 import com.gdsc_knu.official_homepage.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostQueryFactory {
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/post/PostService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/post/PostService.java
@@ -1,0 +1,26 @@
+package com.gdsc_knu.official_homepage.service.post;
+
+import com.gdsc_knu.official_homepage.dto.post.PostResponse;
+import com.gdsc_knu.official_homepage.entity.post.Post;
+import com.gdsc_knu.official_homepage.entity.post.enumeration.Category;
+import com.gdsc_knu.official_homepage.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
+    @Cacheable(value = "trending-post", key = "'Is '+#category", unless="#result.size()<5")
+    public List<PostResponse.Main> getTrendingPosts(Category category, int size) {
+        List<Post> posts = postRepository.findTop5ByCategory(category, size);
+        return posts.stream().map(PostResponse.Main::from).toList();
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/service/post/PostService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/post/PostService.java
@@ -5,13 +5,17 @@ import com.gdsc_knu.official_homepage.entity.post.Post;
 import com.gdsc_knu.official_homepage.entity.post.enumeration.Category;
 import com.gdsc_knu.official_homepage.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PostService {
@@ -22,5 +26,15 @@ public class PostService {
     public List<PostResponse.Main> getTrendingPosts(Category category, int size) {
         List<Post> posts = postRepository.findTop5ByCategory(category, size);
         return posts.stream().map(PostResponse.Main::from).toList();
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void invokeClearPost() {
+        clearTrendingPosts();
+    }
+
+    @CacheEvict(value = "trending-post", allEntries = true, beforeInvocation = true)
+    public void clearTrendingPosts() {
+        log.info("trending post 초기화");
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 게시글 인기순 조회

## To Reviewers 📢
- 인기 게시글의 경우 요청마다 매번 탐색할 필요가 없을 것 같아서 카테고리별로 캐싱해두었고, 스케줄러를 통해 매일 자정 캐싱된 데이터를 지우도록 했습니다.
  - 혹시 매번 업데이트되어야 한다면 좋아요 등록 API에서 백그라운드 작업으로 인기글을 업데이트하는 방법을 고려해보겠습니다.
  - 외에도 다른 좋은방법이 있다면 알려주세요 !
- Post 엔티티에 enum을 숫자로 저장하고 있는 것을 발견하여 수정했습니다. (ddl update 필요)
- 📢 게시글 조회와 관련된 것들은 전부 white list에 들어갈 것 같은데 하실때 '/api/post/**'의 GET 메서드로 와일드카드로 나타내도 좋을 것 같습니다.

## 체크 리스트
- [x] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [x] API 변경사항이 존재합니다.
- [x] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #120 