### PR TITLE
Feat: 이미지 업로드

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ out/
 .vscode/
 
 src/main/resources/static/index.html
+src/main/resources/images/**
 .env

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/post/PostController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/post/PostController.java
@@ -1,16 +1,18 @@
 package com.gdsc_knu.official_homepage.controller.post;
 
+import com.gdsc_knu.official_homepage.dto.fileupload.FileUploadRequest;
+import com.gdsc_knu.official_homepage.dto.fileupload.FileUploadResponse;
 import com.gdsc_knu.official_homepage.dto.post.PostResponse;
 import com.gdsc_knu.official_homepage.entity.post.enumeration.Category;
+import com.gdsc_knu.official_homepage.service.fileupload.FileUploader;
 import com.gdsc_knu.official_homepage.service.post.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,6 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostController {
     private final PostService postService;
+    private final FileUploader fileUploader;
     @GetMapping("trending")
     @Operation(summary = "카테고리별 인기글 5개 조회", description = "category가 null이면 전제를 조회한다.")
     public ResponseEntity<List<PostResponse.Main>> getTrendingPosts(
@@ -27,6 +30,15 @@ public class PostController {
             @RequestParam(value = "size", defaultValue = "5") int size)
     {
         return ResponseEntity.ok().body(postService.getTrendingPosts(category, size));
+    }
+
+    @PostMapping(value = "image",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "이미지 업로드")
+    public ResponseEntity<FileUploadResponse> uploadImage(@Valid @ModelAttribute FileUploadRequest.Create request) {
+        String url = fileUploader.upload(request.getImage(), "post");
+        return ResponseEntity.ok().body(FileUploadResponse.of(url));
     }
 
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/fileupload/FileUploadRequest.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/fileupload/FileUploadRequest.java
@@ -1,0 +1,13 @@
+package com.gdsc_knu.official_homepage.dto.fileupload;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+public class FileUploadRequest {
+    @Getter
+    @AllArgsConstructor
+    public static class Create{
+        private MultipartFile image;
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/fileupload/FileUploadResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/fileupload/FileUploadResponse.java
@@ -1,6 +1,5 @@
 package com.gdsc_knu.official_homepage.dto.fileupload;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/fileupload/FileUploadResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/fileupload/FileUploadResponse.java
@@ -1,0 +1,17 @@
+package com.gdsc_knu.official_homepage.dto.fileupload;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class FileUploadResponse {
+    private final String imageUrl;
+
+    private FileUploadResponse(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public static FileUploadResponse of(String imageUrl) {
+        return new FileUploadResponse(imageUrl);
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/service/fileupload/FileUploader.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/fileupload/FileUploader.java
@@ -1,0 +1,25 @@
+package com.gdsc_knu.official_homepage.service.fileupload;
+
+import com.gdsc_knu.official_homepage.exception.CustomException;
+import com.gdsc_knu.official_homepage.exception.ErrorCode;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface FileUploader {
+    @Retryable(
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 1000),
+            recover = "recover",
+            retryFor = {IOException.class, RuntimeException.class}
+    )
+    String upload(MultipartFile file, String directory);
+
+    @Recover
+    default String recover(Exception e, MultipartFile file){
+        throw new CustomException(ErrorCode.FAILED_UPLOAD);
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/service/fileupload/LocalUploader.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/fileupload/LocalUploader.java
@@ -1,0 +1,37 @@
+package com.gdsc_knu.official_homepage.service.fileupload;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@Profile("local")
+public class LocalUploader implements FileUploader{
+    @Value("${local.storage.path}")
+    private String uploadPath;
+    @Override
+    public String upload(MultipartFile file, String directory) {
+        if (file == null || file.isEmpty()) {
+            return null;
+        }
+        String originalFilename = file.getOriginalFilename();
+
+        String savedFilename = uploadPath + UUID.randomUUID() + "_" + originalFilename;
+        File savedFile = new File(savedFilename);
+        try {
+            file.transferTo(savedFile);
+        } catch (IOException e) {
+            log.error("파일 업로드에 실패하여 재시도합니다.");
+            throw new RuntimeException();
+        }
+
+        return savedFilename;
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/service/fileupload/LocalUploader.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/fileupload/LocalUploader.java
@@ -12,8 +12,8 @@ import java.util.UUID;
 
 @Slf4j
 @Component
-@Profile("local")
-public class LocalUploader implements FileUploader{
+@Profile({"!dev && !prod"})
+public class LocalUploader implements FileUploader {
     @Value("${local.storage.path}")
     private String uploadPath;
     @Override

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -38,6 +38,9 @@ spring:
   sql:
     init:
       mode: never
+local:
+  storage:
+    path: ${LOCAL_FILE_STORAGE:ubuntu/home/images}
 ---
 spring:
   config:

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -16,6 +16,9 @@ spring: #default, test configuration (H2)
     redis:
       host: 127.0.0.1
       port: 6379
+local:
+  storage:
+    path: ${LOCAL_FILE_STORAGE:ubuntu/home/images}
 ---
 spring: # mysql 공통
   config:
@@ -38,9 +41,6 @@ spring:
   sql:
     init:
       mode: never
-local:
-  storage:
-    path: ${LOCAL_FILE_STORAGE:ubuntu/home/images}
 ---
 spring:
   config:


### PR DESCRIPTION
## 🔎 작업 내용
- 이미지 저장 api 구현
- 기존 S3Service를 없애고 인터페이스로 두어 로컬환경과 운영환경의 이미지 저장소를 분리했습니다.

## To Reviewers 📢
- 로컬 이미지 저장소 경로 -> .env에 업데이트했는데, 각자 환경에 맞는 경로로 재설정하면 됩니다. !



## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [x] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #123 