### PR TITLE
지원서 조회 / 게시글 댓글 테스트 코드 작성

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/config/TxTemplateConfig.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/config/TxTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.gdsc_knu.official_homepage.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
+public class TxTemplateConfig {
+    public final TransactionTemplate transactionTemplate;
+
+    public TxTemplateConfig(PlatformTransactionManager transactionManager) {
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+    }
+
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/application/Application.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/application/Application.java
@@ -118,7 +118,7 @@ public class Application extends BaseTimeEntity {
     }
 
     public void updateStatus(ApplicationStatus status) {
-        if (this.applicationStatus == ApplicationStatus.SAVED){
+        if (this.applicationStatus != ApplicationStatus.TEMPORAL){
             this.applicationStatus = status;
         }
     }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/application/Application.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/application/Application.java
@@ -117,12 +117,10 @@ public class Application extends BaseTimeEntity {
         this.isMarked = !this.isMarked;
     }
 
-    public void approve() {
-        this.applicationStatus = ApplicationStatus.APPROVED;
-    }
-
-    public void reject() {
-        this.applicationStatus = ApplicationStatus.REJECTED;
+    public void updateStatus(ApplicationStatus status) {
+        if (this.applicationStatus == ApplicationStatus.SAVED){
+            this.applicationStatus = status;
+        }
     }
 
     public void saveNote(String note) {

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/enumeration/Track.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/enumeration/Track.java
@@ -1,5 +1,15 @@
 package com.gdsc_knu.official_homepage.entity.enumeration;
 
 public enum Track {
-    FRONT_END, BACK_END, ANDROID, AI, DESIGNER, UNDEFINED
+    FRONT_END, BACK_END, ANDROID, AI, DESIGNER, UNDEFINED;
+
+    public static Track[] getValidTrack() {
+        return new Track[] {
+                FRONT_END,
+                BACK_END,
+                ANDROID,
+                AI,
+                DESIGNER
+        };
+    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/CommentRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/CommentRepository.java
@@ -5,11 +5,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c " +
             "FROM Comment c " +
             "WHERE c.post.id = :postId "+
             "ORDER BY c.parent.id ASC, c.createAt ASC")
-    Page<Comment> findCommentAndReply(Pageable pageable, Long postId);
+    Page<Comment> findCommentAndReply(Pageable pageable, @Param(value = "postId") Long postId);
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/MailService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/MailService.java
@@ -75,7 +75,7 @@ public class MailService {
             mailSender.send(message);
         } catch (MessagingException | MailException e) {
             redisRepository.addData(REDIS_KEY, email);
-            throw new CustomException(ErrorCode.FAILED_SEND_MAIL, email + "의 메일 전송에 실패하였습니다: " + e.getMessage());
+            throw new CustomException(ErrorCode.FAILED_SEND_MAIL);
         }
     }
 

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationService.java
@@ -52,7 +52,7 @@ public class AdminApplicationService {
     }
 
     private void addDefaultTrack(Map<String, Integer> trackCountMap){
-        Arrays.stream(Track.values())
+        Arrays.stream(Track.getValidTrack())
                 .forEach(track -> trackCountMap.putIfAbsent(track.name(), 0));
     }
 

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationService.java
@@ -15,9 +15,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
+
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +29,9 @@ import java.util.stream.Collectors;
 public class AdminApplicationService {
     private final ApplicationRepository applicationRepository;
     private final MailService mailService;
-    private final PlatformTransactionManager transactionManager;
+    private final TransactionTemplate transactionTemplate;
+
+
 
     @Transactional(readOnly = true)
     public AdminApplicationResponse.Statistics getStatistic() {
@@ -78,24 +80,17 @@ public class AdminApplicationService {
     }
 
 
-    public void decideApplication(Long id, ApplicationStatus status) {
+    /**
+     * 메일 전송에 실패해도 status 롤백하지 않는다.
+     * 관리자 기능이므로 비동기로 처리하지 않고, 실행결과를 알려준다.
+     */
+    public void decideApplication(Long id, ApplicationStatus applicationStatus) {
         Application application = applicationRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
-        updateApplicationStatus(application, status);
+        transactionTemplate.executeWithoutResult(
+                status -> application.updateStatus(applicationStatus)
+        );
         mailService.sendEach(application);
-    }
-
-    private void updateApplicationStatus(Application application, ApplicationStatus status) {
-        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-        transactionTemplate.executeWithoutResult(transactionStatus -> {
-            if (status == ApplicationStatus.APPROVED) {
-                application.approve();
-            } else if (status == ApplicationStatus.REJECTED) {
-                application.reject();
-            } else {
-                throw new CustomException(ErrorCode.INVALID_APPLICATION_STATE);
-            }
-        });
     }
 
 

--- a/src/test/java/com/gdsc_knu/official_homepage/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/repository/CommentRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.gdsc_knu.official_homepage.repository;
+
+import com.gdsc_knu.official_homepage.OfficialHomepageApplication;
+import com.gdsc_knu.official_homepage.config.QueryDslConfig;
+import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.entity.enumeration.Track;
+import com.gdsc_knu.official_homepage.entity.post.Comment;
+import com.gdsc_knu.official_homepage.entity.post.Post;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+@ContextConfiguration(classes = OfficialHomepageApplication.class)
+public class CommentRepositoryTest {
+    @Autowired private CommentRepository commentRepository;
+    @Autowired private TestEntityManager entityManager;
+
+    private Member author;
+    private Post post;
+    @BeforeEach
+    void setUp() {
+        author = Member.builder()
+                .email("test@email.com")
+                .name("테스트 유저")
+                .track(Track.BACK_END)
+                .build();
+        entityManager.persistAndFlush(author);
+
+        post = Post.builder()
+                .member(author)
+                .build();
+        entityManager.persistAndFlush(post);
+    }
+
+    @Test
+    @DisplayName("댓글의 순서가 올바르게 조회된다")
+    void findCommentAndReply() {
+        // given
+        Comment parent1 = Comment.from("1",author,post,null);
+        Comment child1 = Comment.from("2",author,post,parent1);
+        Comment child2 = Comment.from("3",author,post,parent1);
+        Comment parent2 = Comment.from("4",author,post,null);
+        Comment child3 = Comment.from("5",author,post,parent2);
+        Comment child4 = Comment.from("6",author,post,parent2);
+
+        commentRepository.saveAll(List.of(parent1, parent2, child1, child2, child3, child4));
+        // 2,5 댓글의 생성 시각 나중으로 변경
+        ReflectionTestUtils.setField(child3, "createAt", LocalDateTime.now());
+        ReflectionTestUtils.setField(child1, "createAt", LocalDateTime.now());
+
+        // when
+        Page<Comment> commentList = commentRepository.findCommentAndReply(PageRequest.of(0,6), post.getId());
+
+        // then
+        assertThat(commentList).extracting("content")
+                .containsExactly("1","3","2","4","6","5");
+    }
+
+
+    @Test
+    @DisplayName("부모 댓글 생성 시 자신을 그룹으로 한다.")
+    void save() {
+        // given
+        Comment parent = Comment.from("댓글내용",author,post,null);
+        Comment child = Comment.from("댓글내용",author,post,parent);
+
+        // when
+        commentRepository.saveAll(List.of(parent, child));
+
+        // then
+        assertThat(parent.getParent()).isEqualTo(parent);
+        assertThat(child.getParent()).isEqualTo(parent);
+    }
+
+
+}

--- a/src/test/java/com/gdsc_knu/official_homepage/repository/application/AdminApplicationRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/repository/application/AdminApplicationRepositoryTest.java
@@ -70,9 +70,9 @@ public class AdminApplicationRepositoryTest {
 
     private Application createApplication(int id, ApplicationStatus status) {
         return Application.builder()
-                .email("test"+id+"@email.com")
-                .studentNumber("202400"+id)
-                .phoneNumber("010-0000-"+id)
+                .email(String.format("test%s@email.com", id))
+                .studentNumber(String.valueOf(id))
+                .phoneNumber(String.format("010-0000-%s", id))
                 .applicationStatus(status)
                 .build();
     }

--- a/src/test/java/com/gdsc_knu/official_homepage/repository/application/AdminApplicationRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/repository/application/AdminApplicationRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.gdsc_knu.official_homepage.repository.application;
+
+import com.gdsc_knu.official_homepage.OfficialHomepageApplication;
+import com.gdsc_knu.official_homepage.config.QueryDslConfig;
+import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationStatisticType;
+import com.gdsc_knu.official_homepage.entity.application.Application;
+import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
+import com.gdsc_knu.official_homepage.repository.ApplicationRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+@ContextConfiguration(classes = OfficialHomepageApplication.class)
+public class AdminApplicationRepositoryTest {
+    @Autowired private ApplicationRepository applicationRepository;
+
+    @AfterEach
+    void clear() {
+        applicationRepository.deleteAll();
+    }
+
+
+    @Test
+    @DisplayName("지원 현황을 정상적으로 카운트한다.")
+    void getStatistic() {
+        // given
+        int start = 1;
+        int countPerStatus = 5;
+        List<Application> temporal = createApplicationList(start, start+countPerStatus, ApplicationStatus.TEMPORAL);
+        start+=countPerStatus;
+        List<Application> save = createApplicationList(start, start+countPerStatus, ApplicationStatus.SAVED);
+        start+=countPerStatus;
+        List<Application> approve = createApplicationList(start, start+countPerStatus, ApplicationStatus.APPROVED);
+        start+=countPerStatus;
+        List<Application> reject = createApplicationList(start, start+countPerStatus, ApplicationStatus.REJECTED);
+        List<Application> allApplications = Stream.of(temporal, save, approve, reject)
+                .flatMap(List::stream)
+                .toList();
+        applicationRepository.saveAll(allApplications);
+
+        // when
+        ApplicationStatisticType statistic = applicationRepository.getStatistics();
+
+        // then
+        assertThat(statistic.getTotal()).isEqualTo(15);
+        assertThat(statistic.getApprovedCount()).isEqualTo(5);
+        assertThat(statistic.getRejectedCount()).isEqualTo(5);
+        assertThat(statistic.getOpenCount()).isEqualTo(0);
+    }
+
+    private List<Application> createApplicationList(int startNum, int count, ApplicationStatus status){
+        List<Application> applicationList = new ArrayList<>();
+        for (int i=startNum; i<count; i++) {
+            applicationList.add(createApplication(i, status));
+        }
+        return applicationList;
+    }
+
+    private Application createApplication(int id, ApplicationStatus status) {
+        return Application.builder()
+                .email("test"+id+"@email.com")
+                .studentNumber("202400"+id)
+                .phoneNumber("010-0000-"+id)
+                .applicationStatus(status)
+                .build();
+    }
+}

--- a/src/test/java/com/gdsc_knu/official_homepage/repository/post/CommentRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/repository/post/CommentRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.gdsc_knu.official_homepage.repository;
+package com.gdsc_knu.official_homepage.repository.post;
 
 import com.gdsc_knu.official_homepage.OfficialHomepageApplication;
 import com.gdsc_knu.official_homepage.config.QueryDslConfig;
@@ -6,6 +6,7 @@ import com.gdsc_knu.official_homepage.entity.Member;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 import com.gdsc_knu.official_homepage.entity.post.Comment;
 import com.gdsc_knu.official_homepage.entity.post.Post;
+import com.gdsc_knu.official_homepage.repository.CommentRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationTest.java
@@ -1,0 +1,116 @@
+package com.gdsc_knu.official_homepage.service.admin;
+
+import com.gdsc_knu.official_homepage.entity.application.Application;
+import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
+import com.gdsc_knu.official_homepage.entity.enumeration.Track;
+import com.gdsc_knu.official_homepage.exception.CustomException;
+import com.gdsc_knu.official_homepage.repository.ApplicationRepository;
+import com.gdsc_knu.official_homepage.service.MailService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+
+
+@SpringBootTest
+public class AdminApplicationTest {
+    @Autowired private AdminApplicationService applicationService;
+    @Autowired private ApplicationRepository applicationRepository;
+    @MockBean private MailService mailService;
+
+
+    @AfterEach
+    void clear() {
+        applicationRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("메일 전송에 실패하더라도 status 변경은 저장한다.")
+    void updateStatus() {
+
+    }
+
+    @Test
+    @DisplayName("임시저장 상태인 경우 status 를 변경할 수 없다.")
+    void failedUpdateTemporal() {
+        // given
+        Application application = createApplication(ApplicationStatus.TEMPORAL);
+        applicationRepository.save(application);
+        doThrow(CustomException.class).when(mailService).sendEach(application);
+        // when
+        applicationService.decideApplication(application.getId(), ApplicationStatus.APPROVED);
+        // then
+        assertThat(application.getApplicationStatus()).isEqualTo(ApplicationStatus.TEMPORAL);
+    }
+
+
+    @Test
+    @DisplayName("트랙별 지원서의 개수를 정상적으로 카운트한다.")
+    void getTrackStatistic() {
+        // given
+        int start = 1;
+        int countPerStatus = 2;
+        ApplicationStatus status = ApplicationStatus.SAVED;
+        List<Application> ai = createApplicationList(start, start+countPerStatus, Track.AI, status);
+        start+=countPerStatus;
+        List<Application> backend = createApplicationList(start, start+countPerStatus, Track.BACK_END, status);
+        start+=countPerStatus;
+        List<Application> frontend = createApplicationList(start, start+countPerStatus, Track.FRONT_END, status);
+        start+=countPerStatus;
+        List<Application> temporal = createApplicationList(start, start+countPerStatus, Track.BACK_END, ApplicationStatus.TEMPORAL);
+        List<Application> allApplications = Stream.of(temporal, ai, backend, frontend)
+                .flatMap(List::stream)
+                .toList();
+        applicationRepository.saveAll(allApplications);
+        // when
+        Map<String, Integer> statistic = applicationService.getTrackStatistic();
+        // then
+        assertThat(statistic.get("BACK_END")).isEqualTo(2);
+        assertThat(statistic.get("FRONT_END")).isEqualTo(2);
+        assertThat(statistic.get("AI")).isEqualTo(2);
+        assertThat(statistic.get("DESIGNER")).isEqualTo(0);
+        assertThat(statistic.get("TOTAL")).isEqualTo(6);
+    }
+
+
+
+
+
+    private List<Application> createApplicationList(int startNum, int count, Track track, ApplicationStatus status){
+        List<Application> applicationList = new ArrayList<>();
+        for (int i=startNum; i<count; i++) {
+            applicationList.add(createApplicationByTrack(i, track, status));
+        }
+        return applicationList;
+    }
+
+    private Application createApplicationByTrack(int id, Track track, ApplicationStatus status) {
+        return Application.builder()
+                .email("test"+id+"@email.com")
+                .studentNumber("202400"+id)
+                .phoneNumber("010-0000-"+id)
+                .applicationStatus(status)
+                .track(track)
+                .build();
+    }
+
+    private Application createApplication(ApplicationStatus status) {
+        return Application.builder()
+                .studentNumber("2024000000")
+                .phoneNumber("010-0000-0000")
+                .email("test@email.com")
+                .applicationStatus(status)
+                .build();
+    }
+
+}

--- a/src/test/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationTest.java
@@ -80,6 +80,7 @@ public class AdminApplicationTest {
         assertThat(statistic.get("AI")).isEqualTo(2);
         assertThat(statistic.get("DESIGNER")).isEqualTo(0);
         assertThat(statistic.get("TOTAL")).isEqualTo(6);
+        assertThat(statistic.size()).isEqualTo(6);
     }
 
 

--- a/src/test/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationTest.java
@@ -97,9 +97,9 @@ public class AdminApplicationTest {
 
     private Application createApplicationByTrack(int id, Track track, ApplicationStatus status) {
         return Application.builder()
-                .email("test"+id+"@email.com")
-                .studentNumber("202400"+id)
-                .phoneNumber("010-0000-"+id)
+                .email(String.format("test%s@email.com", id))
+                .studentNumber(String.valueOf(id))
+                .phoneNumber(String.format("010-0000-%s", id))
                 .applicationStatus(status)
                 .track(track)
                 .build();


### PR DESCRIPTION
## 🔎 작업 내용
- 지원 현황 조회 테스트 코드 작성
- 트랙별 지원 개수 테스트 코드 작성
  - 이 과정에서 처음 로그인한 사용자는 track 을  UNDEFINED로 두기로 수정했는데, 해당 필드가 응답에 포함되는 문제를 발견하고 `getValidTrack`을 정의하여 UNDEFINED는 제외하고 가져오도록 수정했습니다.
- 임시저장된 지원서를 합/불 처리 하지 못하는지 테스트 코드 작성
  - 지원서 상태를 변경하는 메서드를 Application 클래스로 옮겨 객체지향적으로 수정
  - 'transaction template` 빈 등록하여 재사용하도록 수정
 
- 댓글 등록 시 그룹이 올바르게 설정되는지 테스트 추가
- 댓글 페이징 조회시 순서가 올바른지 조회 쿼리 테스트 추가 
- 기존 댓글 관련 테스트 코드 리팩토링


## To Reviewers 📢


## 체크 리스트
- [x] 테스트를 작성했습니다.
- [x] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #88