### PR TITLE
어드민 - 지원서 count 쿼리에 기수 필터링 적용

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminApplicationController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminApplicationController.java
@@ -27,15 +27,19 @@ public class AdminApplicationController {
     private static final LocalDate ACTIVE_DATE = LocalDate.of(2025,1,19);
 
     @GetMapping("statistic")
-    @Operation(summary="지원서류 통계데이터 조회 API")
-    public ResponseEntity<AdminApplicationResponse.Statistics> getStatistic() {
-        return ResponseEntity.ok().body(applicationService.getStatistic());
+    @Operation(summary="지원서류 통계데이터 조회 API", description = "classYearId를 비워두거나 false로 설정하면 전체가 조회됩니다.")
+    public ResponseEntity<AdminApplicationResponse.Statistics> getStatistic(
+            @RequestParam(value = "classYearId", required = false) Long classYearId)
+    {
+        return ResponseEntity.ok().body(applicationService.getStatistic(classYearId));
     }
 
     @GetMapping("statistic/track")
-    @Operation(summary="직렬별, 전체 지원서류 개수 조회 API")
-    public ResponseEntity<Map<String, Integer>> getTrackStatistic() {
-        return ResponseEntity.ok().body(applicationService.getTrackStatistic());
+    @Operation(summary="직렬별, 전체 지원서류 개수 조회 API", description = "classYearId를 비워두거나 false로 설정하면 전체가 조회됩니다.")
+    public ResponseEntity<Map<String, Integer>> getTrackStatistic(
+            @RequestParam(value = "classYearId", required = false) Long classYearId)
+    {
+        return ResponseEntity.ok().body(applicationService.getTrackStatistic(classYearId));
     }
 
 

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/application/ApplicationStatisticType.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/application/ApplicationStatisticType.java
@@ -8,4 +8,5 @@ public class ApplicationStatisticType {
     Integer openCount;
     Integer approvedCount;
     Integer rejectedCount;
+    Integer documentPassedCount;
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/application/ApplicationStatisticType.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/application/ApplicationStatisticType.java
@@ -1,8 +1,11 @@
 package com.gdsc_knu.official_homepage.dto.admin.application;
 
-public interface ApplicationStatisticType {
-    Integer getTotal();
-    Integer getOpenCount();
-    Integer getApprovedCount();
-    Integer getRejectedCount();
+import lombok.Getter;
+
+@Getter
+public class ApplicationStatisticType {
+    Integer total;
+    Integer openCount;
+    Integer approvedCount;
+    Integer rejectedCount;
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/application/ApplicationTrackType.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/application/ApplicationTrackType.java
@@ -1,7 +1,15 @@
 package com.gdsc_knu.official_homepage.dto.admin.application;
 
+import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 
-public interface ApplicationTrackType {
-    String getTrack();
-    Integer getCount();
+public class ApplicationTrackType {
+    Track track;
+    Long count;
+
+    public String getTrack() {
+        return track.name();
+    }
+    public Integer getCount() {
+        return count.intValue();
+    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/application/ApplicationQueryFactory.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/application/ApplicationQueryFactory.java
@@ -1,10 +1,18 @@
 package com.gdsc_knu.official_homepage.repository.application;
 
+import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationStatisticType;
+import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationTrackType;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface ApplicationQueryFactory {
     Page<Application> findAllApplicationsByOption(Pageable pageable, Track track, Boolean isMarked, Long classYearId);
+
+    ApplicationStatisticType getStatistics(Long classYearId);
+
+    List<ApplicationTrackType> getGroupByTrack(Long classYearId);
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/application/ApplicationQueryFactoryImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/application/ApplicationQueryFactoryImpl.java
@@ -1,10 +1,13 @@
 package com.gdsc_knu.official_homepage.repository.application;
 
+import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationStatisticType;
+import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationTrackType;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.entity.application.QApplication;
-import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -13,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import static com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus.*;
 
 
 @Repository
@@ -23,7 +27,7 @@ public class ApplicationQueryFactoryImpl implements ApplicationQueryFactory{
     public Page<Application> findAllApplicationsByOption(Pageable pageable, Track track, Boolean isMarked, Long classYearId) {
         List<Application> applications = jpaQueryFactory
                 .selectFrom(QApplication.application)
-                .where(QApplication.application.applicationStatus.ne(ApplicationStatus.TEMPORAL)
+                .where(QApplication.application.applicationStatus.ne(TEMPORAL)
                         .and(eqTrack(track))
                         .and(eqIsMarked(isMarked))
                         .and(eqClassYear(classYearId)))
@@ -35,7 +39,7 @@ public class ApplicationQueryFactoryImpl implements ApplicationQueryFactory{
         Long total = jpaQueryFactory
                 .select(QApplication.application.count())
                 .from(QApplication.application)
-                .where(QApplication.application.applicationStatus.ne(ApplicationStatus.TEMPORAL)
+                .where(QApplication.application.applicationStatus.ne(TEMPORAL)
                         .and(eqTrack(track))
                         .and(eqIsMarked(isMarked))
                         .and(eqClassYear(classYearId)))
@@ -43,6 +47,38 @@ public class ApplicationQueryFactoryImpl implements ApplicationQueryFactory{
         return new PageImpl<>(applications, pageable, total == null ? 0 : total);
     }
 
+    @Override
+    public ApplicationStatisticType getStatistics(Long classYearId) {
+        return jpaQueryFactory
+            .select(Projections.fields(ApplicationStatisticType.class,
+                new CaseBuilder().when(QApplication.application.applicationStatus.ne(TEMPORAL))
+                        .then(1).otherwise(0).sum().as("total"),
+                new CaseBuilder().when(QApplication.application.applicationStatus.ne(TEMPORAL)
+                        .and(QApplication.application.isOpened.eq(true)))
+                        .then(1).otherwise(0).sum().as("openCount"),
+                new CaseBuilder().when(QApplication.application.applicationStatus.eq(APPROVED))
+                        .then(1).otherwise(0).sum().as("approvedCount"),
+                new CaseBuilder().when(QApplication.application.applicationStatus.eq(REJECTED))
+                        .then(1).otherwise(0).sum().as("rejectedCount")
+            ))
+            .from(QApplication.application)
+            .where(eqClassYear(classYearId))
+            .fetchOne();
+    }
+
+    @Override
+    public List<ApplicationTrackType> getGroupByTrack(Long classYearId) {
+        return jpaQueryFactory
+                .select(Projections.fields(ApplicationTrackType.class,
+                        QApplication.application.track.as("track"),
+                        QApplication.application.count().as("count")
+                ))
+                .from(QApplication.application)
+                .where(QApplication.application.applicationStatus.ne(TEMPORAL)
+                        .and(eqClassYear(classYearId)))
+                .groupBy(QApplication.application.track)
+                .fetch();
+    }
 
 
     private BooleanExpression eqTrack(Track track) {

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/application/ApplicationQueryFactoryImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/application/ApplicationQueryFactoryImpl.java
@@ -62,7 +62,9 @@ public class ApplicationQueryFactoryImpl implements ApplicationQueryFactory{
                 new CaseBuilder().when(application.applicationStatus.eq(APPROVED))
                         .then(1).otherwise(0).sum().as("approvedCount"),
                 new CaseBuilder().when(application.applicationStatus.eq(REJECTED))
-                        .then(1).otherwise(0).sum().as("rejectedCount")
+                        .then(1).otherwise(0).sum().as("rejectedCount"),
+                new CaseBuilder().when(application.isMarked.eq(true))
+                        .then(1).otherwise(0).sum().as("documentPassedCount")
             ))
             .from(application)
             .where(eqClassYear(classYearId))

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/application/ApplicationQueryFactoryImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/application/ApplicationQueryFactoryImpl.java
@@ -37,7 +37,8 @@ public class ApplicationQueryFactoryImpl implements ApplicationQueryFactory{
                 .from(QApplication.application)
                 .where(QApplication.application.applicationStatus.ne(ApplicationStatus.TEMPORAL)
                         .and(eqTrack(track))
-                        .and(eqIsMarked(isMarked)))
+                        .and(eqIsMarked(isMarked))
+                        .and(eqClassYear(classYearId)))
                 .fetchFirst();
         return new PageImpl<>(applications, pageable, total == null ? 0 : total);
     }

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/application/ApplicationRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/application/ApplicationRepository.java
@@ -1,9 +1,6 @@
 package com.gdsc_knu.official_homepage.repository.application;
 
-import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationStatisticType;
-import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationTrackType;
 import com.gdsc_knu.official_homepage.entity.application.Application;
-import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,32 +12,15 @@ import java.util.Optional;
 import java.util.Set;
 
 @Repository
-public interface ApplicationRepository extends JpaRepository<Application, Long>, ApplicationQueryFactory{
+public interface ApplicationRepository extends JpaRepository<Application, Long>, ApplicationQueryFactory {
     Optional<Application> findByNameAndStudentNumberAndClassYearId(String name, String studentNumber, Long classYearId);
-    Optional<Application> findByStudentNumber(String studentNumber);
+
     @Query("SELECT a " +
             "FROM Application a LEFT JOIN FETCH a.answers "+
             "WHERE a.id=:id")
     Optional<Application> findByIdFetchJoin(Long id);
 
-    @Query("SELECT " +
-            "COUNT(CASE WHEN a.applicationStatus != 'TEMPORAL' THEN 1 END) AS total, " +
-            "COUNT(CASE WHEN a.isOpened = true AND a.applicationStatus != 'TEMPORAL' THEN 1 END) AS openCount, " +
-            "COUNT(CASE WHEN a.applicationStatus = 'APPROVED' THEN 1 END) AS approvedCount, " +
-            "COUNT(CASE WHEN a.applicationStatus = 'REJECTED' THEN 1 END) AS rejectedCount " +
-            "FROM Application a")
-    ApplicationStatisticType getStatistics();
-
-
-    @Query("SELECT a.track as track, COUNT(*) as count " +
-            "FROM Application a " +
-            "WHERE a.applicationStatus != 'TEMPORAL' " +
-            "GROUP BY a.track")
-    List<ApplicationTrackType> getGroupByTrack();
-
     Page<Application> findByNameContaining(Pageable pageable, String name);
-
-    List<Application> findByApplicationStatusIn(List<ApplicationStatus> applicationStatus);
 
     List<Application> findByEmailIn(Set<Object> email);
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationService.java
@@ -1,21 +1,17 @@
 package com.gdsc_knu.official_homepage.service.admin;
 
 import com.gdsc_knu.official_homepage.dto.PagingResponse;
-import com.gdsc_knu.official_homepage.dto.admin.application.AdminApplicationRequest;
 import com.gdsc_knu.official_homepage.dto.admin.application.AdminApplicationResponse;
 import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationStatisticType;
 import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationTrackType;
-import com.gdsc_knu.official_homepage.entity.ClassYear;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 import com.gdsc_knu.official_homepage.exception.CustomException;
 import com.gdsc_knu.official_homepage.exception.ErrorCode;
 import com.gdsc_knu.official_homepage.repository.application.ApplicationRepository;
-import com.gdsc_knu.official_homepage.repository.application.ClassYearRepository;
 import com.gdsc_knu.official_homepage.service.MailService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -34,19 +30,17 @@ public class AdminApplicationService {
     private final ApplicationRepository applicationRepository;
     private final MailService mailService;
     private final TransactionTemplate transactionTemplate;
-    private final ClassYearRepository classYearRepository;
-
 
 
     @Transactional(readOnly = true)
-    public AdminApplicationResponse.Statistics getStatistic() {
-        ApplicationStatisticType statistic = applicationRepository.getStatistics();
+    public AdminApplicationResponse.Statistics getStatistic(Long classYearId) {
+        ApplicationStatisticType statistic = applicationRepository.getStatistics(classYearId);
         return AdminApplicationResponse.Statistics.from(statistic);
     }
 
     @Transactional(readOnly = true)
-    public Map<String, Integer> getTrackStatistic() {
-        List<ApplicationTrackType> trackStatistics = applicationRepository.getGroupByTrack();
+    public Map<String, Integer> getTrackStatistic(Long classYearId) {
+        List<ApplicationTrackType> trackStatistics = applicationRepository.getGroupByTrack(classYearId);
 
         Map<String, Integer> trackCountMap = trackStatistics.stream()
                 .collect(Collectors.toMap(ApplicationTrackType::getTrack, ApplicationTrackType::getCount));

--- a/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
@@ -52,4 +52,10 @@ public class ApplicationTestEntityFactory {
             applications.get(i).updateClassYear(classYears.get(classYearIdx));
         }
     }
+
+    public static void setClassYear(List<Application> applications, ClassYear classYear) {
+        for (int i = 0; i < applications.size(); i++) {
+            applications.get(i).updateClassYear(classYear);
+        }
+    }
 }

--- a/src/test/java/com/gdsc_knu/official_homepage/application/repository/AdminApplicationRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/repository/AdminApplicationRepositoryTest.java
@@ -52,13 +52,10 @@ public class AdminApplicationRepositoryTest {
         // given (status 마다 더미데이터를 countPerStatus 씩 생성한다.)
         int start = 1;
         int countPerStatus = 5;
-        List<Application> temporal = createApplicationList(start, start+countPerStatus, AI, TEMPORAL);
-        start+=countPerStatus;
-        List<Application> save = createApplicationList(start, start+countPerStatus, AI, SAVED);
-        start+=countPerStatus;
-        List<Application> approve = createApplicationList(start, start+countPerStatus, AI, APPROVED);
-        start+=countPerStatus;
-        List<Application> reject = createApplicationList(start, start+countPerStatus, AI, REJECTED);
+        List<Application> temporal = createApplicationList(start, start+=countPerStatus, AI, TEMPORAL);
+        List<Application> save = createApplicationList(start, start+=countPerStatus, AI, SAVED);
+        List<Application> approve = createApplicationList(start, start+=countPerStatus, AI, APPROVED);
+        List<Application> reject = createApplicationList(start, start+=countPerStatus, AI, REJECTED);
         List<Application> allApplications = Stream.of(temporal, save, approve, reject)
                 .flatMap(List::stream)
                 .toList();
@@ -68,7 +65,7 @@ public class AdminApplicationRepositoryTest {
         applicationRepository.saveAll(allApplications);
 
         // when
-        ApplicationStatisticType statistic = applicationRepository.getStatistics();
+        ApplicationStatisticType statistic = applicationRepository.getStatistics(null);
 
         // then
         assertThat(statistic.getTotal()).isEqualTo(15);
@@ -78,16 +75,31 @@ public class AdminApplicationRepositoryTest {
     }
 
     @Test
+    @DisplayName("지원 및 합격 개수를 기수로 필터링하여 카운트한다.")
+    void getStatisticByClassYear() {
+        // given (기수 3개 지원서 9개를 생성한다.)
+        List<ClassYear> classYears = createClassYearList(1, 1+3);
+        classYearRepository.saveAll(classYears);
+        List<Application> applications = createApplicationList(1, 1+9, AI, SAVED);
+        setClassYear(applications, classYears);
+        applicationRepository.saveAll(applications);
+
+        // when
+        ApplicationStatisticType statistic = applicationRepository.getStatistics(2L);
+
+        // then (2기 지원서가 3개 조회된다.)
+        assertThat(statistic.getTotal()).isEqualTo(3);
+    }
+
+    @Test
     @DisplayName("트랙별 지원 현황을 조회한다. 임시저장 지원서는 결과에 포함하지 않는다.")
     void getGroupByTrack() {
         // given (track 마다 더미데이터를 countPerStatus 씩 생성한다.)
         int start = 1;
         int countPerStatus = 2;
-        List<Application> ai = createApplicationList(start, start+countPerStatus, AI, SAVED);
-        start+=countPerStatus;
-        List<Application> backend = createApplicationList(start, start+countPerStatus, BACK_END, SAVED);
-        start+=countPerStatus;
-        List<Application> temporal = createApplicationList(start, start+countPerStatus, BACK_END, TEMPORAL);
+        List<Application> ai = createApplicationList(start, start+=countPerStatus, AI, SAVED);
+        List<Application> backend = createApplicationList(start, start+=countPerStatus, BACK_END, SAVED);
+        List<Application> temporal = createApplicationList(start, start+=countPerStatus, BACK_END, TEMPORAL);
         List<Application> allApplications = Stream.of(temporal, ai, backend)
                 .flatMap(List::stream)
                 .toList();
@@ -97,7 +109,7 @@ public class AdminApplicationRepositoryTest {
         applicationRepository.saveAll(allApplications);
 
         // when
-        List<ApplicationTrackType> groupStatistic = applicationRepository.getGroupByTrack();
+        List<ApplicationTrackType> groupStatistic = applicationRepository.getGroupByTrack(null);
         Map<String, Integer> trackCountMap = groupStatistic.stream()
                 .collect(Collectors.toMap(ApplicationTrackType::getTrack, ApplicationTrackType::getCount));
 
@@ -145,11 +157,9 @@ public class AdminApplicationRepositoryTest {
         // given (옵션별 더미데이터를 countPerStatus 씩 생성한다.)
         int start = 1;
         int countPerStatus = 2;
-        List<Application> ai = createApplicationList(start, start+countPerStatus, AI, SAVED);
-        start+=countPerStatus;
-        List<Application> backend = createApplicationList(start, start+countPerStatus, BACK_END, SAVED);
-        start+=countPerStatus;
-        List<Application> temporal = createApplicationList(start, start+countPerStatus, BACK_END, TEMPORAL);
+        List<Application> ai = createApplicationList(start, start+=countPerStatus, AI, SAVED);
+        List<Application> backend = createApplicationList(start, start+=countPerStatus, BACK_END, SAVED);
+        List<Application> temporal = createApplicationList(start, start+=countPerStatus, BACK_END, TEMPORAL);
         List<Application> allApplications = Stream.of(temporal, ai, backend)
                 .flatMap(List::stream)
                 .toList();
@@ -172,9 +182,9 @@ public class AdminApplicationRepositoryTest {
     @DisplayName("기수별 지원서를 페이징 조회한다.")
     void findAllByClassYear() {
         // given (총 6개의 지원서와 3개의 기수를 생성하여 매핑한다.)
-        List<ClassYear> classYears = createClassYearList(1, 3);
+        List<ClassYear> classYears = createClassYearList(1, 1+3);
         classYearRepository.saveAll(classYears);
-        List<Application> applications = createApplicationList(1, 6, AI, SAVED);
+        List<Application> applications = createApplicationList(1, 1+6, AI, SAVED);
         setClassYear(applications, classYears);
         applicationRepository.saveAll(applications);
 

--- a/src/test/java/com/gdsc_knu/official_homepage/application/repository/AdminApplicationRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/repository/AdminApplicationRepositoryTest.java
@@ -8,7 +8,6 @@ import com.gdsc_knu.official_homepage.entity.ClassYear;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.repository.application.ApplicationRepository;
 import com.gdsc_knu.official_homepage.repository.application.ClassYearRepository;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +28,7 @@ import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFa
 import static com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus.*;
 import static com.gdsc_knu.official_homepage.entity.enumeration.Track.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 
 @DataJpaTest
@@ -49,7 +49,7 @@ public class AdminApplicationRepositoryTest {
     @Test
     @DisplayName("지원 및 합격 개수를 정상적으로 카운트한다. 임시저장 지원서는 통계에 포함하지 않는다.")
     void getStatistic() {
-        // given
+        // given (status 마다 더미데이터를 countPerStatus 씩 생성한다.)
         int start = 1;
         int countPerStatus = 5;
         List<Application> temporal = createApplicationList(start, start+countPerStatus, AI, TEMPORAL);
@@ -62,10 +62,9 @@ public class AdminApplicationRepositoryTest {
         List<Application> allApplications = Stream.of(temporal, save, approve, reject)
                 .flatMap(List::stream)
                 .toList();
-        int classYearStart = 1;
-        List<ClassYear> allClassYears = createClassYearList(classYearStart, classYearStart+countPerStatus);
-        classYearRepository.saveAll(allClassYears);
-        setClassYear(allApplications, allClassYears);
+        ClassYear classYear = createClassYear(1L);
+        classYearRepository.save(classYear);
+        setClassYear(allApplications, classYear);
         applicationRepository.saveAll(allApplications);
 
         // when
@@ -81,7 +80,7 @@ public class AdminApplicationRepositoryTest {
     @Test
     @DisplayName("트랙별 지원 현황을 조회한다. 임시저장 지원서는 결과에 포함하지 않는다.")
     void getGroupByTrack() {
-        // given
+        // given (track 마다 더미데이터를 countPerStatus 씩 생성한다.)
         int start = 1;
         int countPerStatus = 2;
         List<Application> ai = createApplicationList(start, start+countPerStatus, AI, SAVED);
@@ -92,10 +91,9 @@ public class AdminApplicationRepositoryTest {
         List<Application> allApplications = Stream.of(temporal, ai, backend)
                 .flatMap(List::stream)
                 .toList();
-        int classYearStart = 1;
-        List<ClassYear> allClassYears = createClassYearList(classYearStart, classYearStart+countPerStatus);
-        classYearRepository.saveAll(allClassYears);
-        setClassYear(allApplications, allClassYears);
+        ClassYear classYear = createClassYear(1L);
+        classYearRepository.save(classYear);
+        setClassYear(allApplications, classYear);
         applicationRepository.saveAll(allApplications);
 
         // when
@@ -112,6 +110,7 @@ public class AdminApplicationRepositoryTest {
     @Test
     @DisplayName("트랙 / 열람여부로 지원서를 페이징 조회한다. 임시저장 지원서는 결과에 포함하지 않는다.")
     void findAllApplicationsByOption() {
+        // given (옵션 마다 더미데이터를 countPerStatus 씩 생성한다.)
         int start = 1;
         int countPerStatus = 2;
         List<Application> ai = createApplicationList(start, start+countPerStatus, AI, SAVED);
@@ -122,10 +121,9 @@ public class AdminApplicationRepositoryTest {
         List<Application> allApplications = Stream.of(temporal, ai, backend)
                 .flatMap(List::stream)
                 .toList();
-        int classYearStart = 1;
-        List<ClassYear> allClassYears = createClassYearList(classYearStart, classYearStart+countPerStatus);
-        classYearRepository.saveAll(allClassYears);
-        setClassYear(allApplications, allClassYears);
+        ClassYear classYear = createClassYear(1L);
+        classYearRepository.save(classYear);
+        setClassYear(allApplications, classYear);
         applicationRepository.saveAll(allApplications);
 
         // when
@@ -142,8 +140,9 @@ public class AdminApplicationRepositoryTest {
 
 
     @Test
-    @DisplayName("트랙 / 열람여부에 값이 없으면 전체를 조회한다.")
+    @DisplayName("트랙 / 열람여부 / 기수에 값이 없으면 전체를 조회한다.")
     void findAllApplicationsByOptionWithNull() {
+        // given (옵션별 더미데이터를 countPerStatus 씩 생성한다.)
         int start = 1;
         int countPerStatus = 2;
         List<Application> ai = createApplicationList(start, start+countPerStatus, AI, SAVED);
@@ -154,10 +153,9 @@ public class AdminApplicationRepositoryTest {
         List<Application> allApplications = Stream.of(temporal, ai, backend)
                 .flatMap(List::stream)
                 .toList();
-        int classYearStart = 1;
-        List<ClassYear> allClassYears = createClassYearList(classYearStart, classYearStart+countPerStatus);
-        classYearRepository.saveAll(allClassYears);
-        setClassYear(allApplications, allClassYears);
+        ClassYear classYear = createClassYear(1L);
+        classYearRepository.save(classYear);
+        setClassYear(allApplications, classYear);
         applicationRepository.saveAll(allApplications);
 
         // when
@@ -167,6 +165,34 @@ public class AdminApplicationRepositoryTest {
         // then
         assertThat(applicationPage).hasSize(4).anySatisfy(
                 application -> assertThat(application.getTrack()).isEqualTo(AI)
+        );
+    }
+
+    @Test
+    @DisplayName("기수별 지원서를 페이징 조회한다.")
+    void findAllByClassYear() {
+        // given (총 6개의 지원서와 3개의 기수를 생성하여 매핑한다.)
+        List<ClassYear> classYears = createClassYearList(1, 3);
+        classYearRepository.saveAll(classYears);
+        List<Application> applications = createApplicationList(1, 6, AI, SAVED);
+        setClassYear(applications, classYears);
+        applicationRepository.saveAll(applications);
+
+        // when
+        PageRequest pageRequest = PageRequest.of(0,5);
+        Page<Application> applicationPage = applicationRepository.findAllApplicationsByOption(pageRequest,null, null, 1L);
+
+        // then
+        // 필터링 된 지원서 검증
+        assertThat(applicationPage).hasSize(2).allSatisfy(
+                application -> assertThat(application.getClassYear().getId()).isEqualTo(1L)
+        );
+        // count 쿼리 검증
+        assertAll(()->
+            {
+                assertThat(applicationPage.getTotalPages()).isEqualTo(1L);
+                assertThat(applicationPage.hasNext()).isFalse();
+            }
         );
     }
 }

--- a/src/test/java/com/gdsc_knu/official_homepage/application/repository/AdminApplicationRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/repository/AdminApplicationRepositoryTest.java
@@ -92,6 +92,27 @@ public class AdminApplicationRepositoryTest {
     }
 
     @Test
+    @DisplayName("서류합격 지원서 개수를 카운트한다.")
+    void getStatisticDocumentPass() {
+        // given
+        ClassYear classYear = createClassYear(1L);
+        classYearRepository.save(classYear);
+        List<Application> applications = createApplicationList(1, 1+4, AI, SAVED);
+        setClassYear(applications, classYear);
+        // mark 를 바꾸면 서류합격
+        for (int i=0; i<2; i++) {
+            applications.get(i).changeMark();
+        }
+        applicationRepository.saveAll(applications);
+
+        // when
+        ApplicationStatisticType statistic = applicationRepository.getStatistics(null);
+
+        // then
+        assertThat(statistic.getDocumentPassedCount()).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("트랙별 지원 현황을 조회한다. 임시저장 지원서는 결과에 포함하지 않는다.")
     void getGroupByTrack() {
         // given (track 마다 더미데이터를 countPerStatus 씩 생성한다.)

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
@@ -1,7 +1,6 @@
 package com.gdsc_knu.official_homepage.application.service;
 
 import com.gdsc_knu.official_homepage.ClearDatabase;
-import com.gdsc_knu.official_homepage.config.QueryDslConfig;
 import com.gdsc_knu.official_homepage.entity.ClassYear;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
@@ -12,7 +11,6 @@ import com.gdsc_knu.official_homepage.repository.application.ApplicationReposito
 import com.gdsc_knu.official_homepage.repository.application.ClassYearRepository;
 import com.gdsc_knu.official_homepage.service.MailService;
 import com.gdsc_knu.official_homepage.service.admin.AdminApplicationService;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -64,12 +61,12 @@ public class AdminApplicationServiceTest {
         classYearRepository.save(classYear);
         application.updateClassYear(classYear);
         applicationRepository.save(application);
-        doThrow(CustomException.class).when(mailService).sendEach(application);
+        doThrow(CustomException.class).when(mailService).sendEach(any());
         // when
-        // then
         assertThrows(CustomException.class, () ->
                 applicationService.decideApplication(application.getId(), ApplicationStatus.APPROVED)
         );
+        // then
         assertThat(application.getApplicationStatus()).isEqualTo(ApplicationStatus.APPROVED);
     }
 
@@ -78,7 +75,7 @@ public class AdminApplicationServiceTest {
     @DisplayName("트랙별 지원서의 개수를 정상적으로 카운트한다. (트랙에 지원이 없는 경우 0을 카운트한다.)")
     void getTrackStatistic() {
         // given
-        int start = 2;
+        int start = 1;
         int countPerStatus = 2;
         ApplicationStatus status = ApplicationStatus.SAVED;
         List<Application> ai = createApplicationList(start, start+countPerStatus, Track.AI, status);
@@ -112,7 +109,7 @@ public class AdminApplicationServiceTest {
     @DisplayName("지원서 메모가 이미 수정된 경우 다시 수정을 시도할 때 오류를 반환한다.")
     void updateNoteFailed() {
         // given
-        Application application = createApplication(null, Track.AI, ApplicationStatus.SAVED);
+        Application application = createApplication(1L, Track.AI, ApplicationStatus.SAVED);
         ClassYear classYear = createClassYear(1L);
         classYearRepository.save(classYear);
         application.updateClassYear(classYear);
@@ -133,7 +130,7 @@ public class AdminApplicationServiceTest {
     @Test
     @DisplayName("동시에 지원서를 수정하는 경우 처음 시도만 남고 오류를 반환한다.")
     void updateNoteConcurrentFailed() throws InterruptedException {
-        Application application = createApplication(null, Track.AI, ApplicationStatus.SAVED);
+        Application application = createApplication(1L, Track.AI, ApplicationStatus.SAVED);
         ClassYear classYear = createClassYear(1L);
         classYearRepository.save(classYear);
         application.updateClassYear(classYear);

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
@@ -78,17 +78,16 @@ public class AdminApplicationServiceTest {
         int start = 1;
         int countPerStatus = 2;
         ApplicationStatus status = ApplicationStatus.SAVED;
-        List<Application> ai = createApplicationList(start, start+countPerStatus, Track.AI, status);
+        List<Application> ai = createApplicationList(start, start+=countPerStatus, Track.AI, status);
         List<Application> backend = createApplicationList(start, start+=countPerStatus, Track.BACK_END, status);
         List<Application> frontend = createApplicationList(start, start+=countPerStatus, Track.FRONT_END, status);
         List<Application> temporal = createApplicationList(start, start+=countPerStatus, Track.BACK_END, ApplicationStatus.TEMPORAL);
         List<Application> allApplications = Stream.of(ai, backend, frontend, temporal)
                 .flatMap(List::stream)
                 .toList();
-        int classYearStart = 1;
-        List<ClassYear> allClassYears = createClassYearList(classYearStart, classYearStart+countPerStatus);
-        classYearRepository.saveAll(allClassYears);
-        setClassYear(allApplications, allClassYears);
+        ClassYear classYear = createClassYear(1L);
+        classYearRepository.save(classYear);
+        setClassYear(allApplications, classYear);
         applicationRepository.saveAll(allApplications);
         // when
         Map<String, Integer> statistic = applicationService.getTrackStatistic(null);

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
@@ -79,12 +79,9 @@ public class AdminApplicationServiceTest {
         int countPerStatus = 2;
         ApplicationStatus status = ApplicationStatus.SAVED;
         List<Application> ai = createApplicationList(start, start+countPerStatus, Track.AI, status);
-        start+=countPerStatus;
-        List<Application> backend = createApplicationList(start, start+countPerStatus, Track.BACK_END, status);
-        start+=countPerStatus;
-        List<Application> frontend = createApplicationList(start, start+countPerStatus, Track.FRONT_END, status);
-        start+=countPerStatus;
-        List<Application> temporal = createApplicationList(start, start+countPerStatus, Track.BACK_END, ApplicationStatus.TEMPORAL);
+        List<Application> backend = createApplicationList(start, start+=countPerStatus, Track.BACK_END, status);
+        List<Application> frontend = createApplicationList(start, start+=countPerStatus, Track.FRONT_END, status);
+        List<Application> temporal = createApplicationList(start, start+=countPerStatus, Track.BACK_END, ApplicationStatus.TEMPORAL);
         List<Application> allApplications = Stream.of(ai, backend, frontend, temporal)
                 .flatMap(List::stream)
                 .toList();
@@ -94,7 +91,7 @@ public class AdminApplicationServiceTest {
         setClassYear(allApplications, allClassYears);
         applicationRepository.saveAll(allApplications);
         // when
-        Map<String, Integer> statistic = applicationService.getTrackStatistic();
+        Map<String, Integer> statistic = applicationService.getTrackStatistic(null);
         // then
         assertThat(statistic.get("BACK_END")).isEqualTo(2);
         assertThat(statistic.get("FRONT_END")).isEqualTo(2);


### PR DESCRIPTION
## 🔎 작업 내용
- 지원서 목록 페이징 조회에서 count 쿼리에 기수 필터링 빠진거 추가
- 직렬별 통계 쿼리에 기수 필터링 추가
- 지원현황 통계 쿼리에 기수 필터링 추가

## To Reviewers 📢
- 지원현황에 이전 api랑 호환성 지켜지도록 서류 합격 필드 한개만 추가했습니다.
- 이전에 수정하신 지원서 목록 테스트 코드에서 기수를 여러개 생성할 필요없는 부분에 대해서는 1개만 생성하도록 수정했습니다.

## 체크 리스트
- [x] 테스트를 작성했습니다.
- [x] 테스트를 통과했습니다.
- [x] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [x] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #153 