### PR TITLE
지원서 테스트 코드 추가 및 오류 수정

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/entity/application/Application.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/application/Application.java
@@ -109,7 +109,7 @@ public class Application {
                 .collect(Collectors.toMap(ApplicationAnswer::getQuestionNumber, answer -> answer));
         int answerSize = oldAnswers.size();
         if (answerSize != newAnswers.size()) {
-            throw new IllegalArgumentException("지원서의 질문 응답 개수가 일치하지 않습니다.");
+            throw new CustomException(ErrorCode.APPLICATION_ANSWER_UNMATCHED);
         }
         for (int i = 0; i < answerSize; i++) {
             if (!oldAnswers.get(i).getAnswer().equals(newAnswers.get(i))) {

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/application/Application.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/application/Application.java
@@ -83,6 +83,7 @@ public class Application {
                 .map(answers -> ApplicationAnswer.builder()
                         .questionNumber(answers.getQuestionNumber())
                         .answer(answers.getAnswer())
+                        .application(this)
                         .build()).toList();
         this.submittedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/gdsc_knu/official_homepage/exception/ErrorCode.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/exception/ErrorCode.java
@@ -28,12 +28,13 @@ public enum ErrorCode {
     APPLICATION_NOT_FOUND(404,HttpStatus.NOT_FOUND, "지원서를 찾을 수 없습니다","A404"),
     APPLICATION_CONFLICT(409, HttpStatus.CONFLICT, "이미 작성 중이거나 최종 제출한 지원서가 존재합니다.","A409"),
     INVALID_APPLICATION_STATE(400, HttpStatus.BAD_REQUEST,"지원서 상태가 유효하지 않습니다.","A400"),
-    APPLICATION_DEADLINE_EXPIRED(400, HttpStatus.BAD_REQUEST,"지원 기간이 만료되었습니다.","AA400"),
+    APPLICATION_DEADLINE_EXPIRED(400, HttpStatus.BAD_REQUEST,"지원 기간이 만료되었습니다.","AD400"),
     CLASS_YEAR_NOT_FOUND(404, HttpStatus.NOT_FOUND,"존재하지 않는 기수입니다.","AC404"),
     INVALID_CLASS_YEAR(400, HttpStatus.BAD_REQUEST,"기수 정보 설정이 잘못 되었습니다.","AC400"),
     CLASS_YEAR_DUPLICATED(409, HttpStatus.CONFLICT,"이미 존재하는 기수 이름입니다.","AC409"),
     APPLICATION_FORBIDDEN(403, HttpStatus.FORBIDDEN, "지원서에 접근할 수 있는 권한이 없습니다.","A403"),
     CONCURRENT_FAILED(409, HttpStatus.CONFLICT, "다른 사용자가 수정중입니다.","AN409"),
+    APPLICATION_ANSWER_UNMATCHED(400, HttpStatus.BAD_REQUEST, "답변 개수가 일치하지 않습니다.","AA400"),
     // Team
 
 

--- a/src/main/java/com/gdsc_knu/official_homepage/exception/ErrorCode.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/exception/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
 
     // Application
     APPLICATION_NOT_FOUND(404,HttpStatus.NOT_FOUND, "지원서를 찾을 수 없습니다","A404"),
-    APPLICATION_DUPLICATED(409, HttpStatus.CONFLICT, "이미 작성 중이거나 최종 제출한 지원서가 존재합니다.","A409"),
+    APPLICATION_CONFLICT(409, HttpStatus.CONFLICT, "이미 작성 중이거나 최종 제출한 지원서가 존재합니다.","A409"),
     INVALID_APPLICATION_STATE(400, HttpStatus.BAD_REQUEST,"지원서 상태가 유효하지 않습니다.","A400"),
     APPLICATION_DEADLINE_EXPIRED(400, HttpStatus.BAD_REQUEST,"지원 기간이 만료되었습니다.","AA400"),
     CLASS_YEAR_NOT_FOUND(404, HttpStatus.NOT_FOUND,"존재하지 않는 기수입니다.","AC404"),

--- a/src/main/java/com/gdsc_knu/official_homepage/service/application/ApplicationServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/application/ApplicationServiceImpl.java
@@ -59,7 +59,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         Member member = validateMember(email);
         applicationRepository.findByNameAndStudentNumberAndClassYearId(member.getName(), member.getStudentNumber(), applicationRequest.getClassYearId())
             .ifPresent(application -> {
-                throw new CustomException(ErrorCode.APPLICATION_DUPLICATED);
+                throw new CustomException(ErrorCode.APPLICATION_CONFLICT);
             });
         member.updateTrack(applicationRequest.getTrack());
         Application application =  new Application(member, new ApplicationModel(applicationRequest));
@@ -122,7 +122,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         Application application = applicationRepository.findByNameAndStudentNumberAndClassYearId(name, studentNumber, classYearId)
                 .orElseThrow(() -> new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
         if (!application.getApplicationStatus().equals(ApplicationStatus.TEMPORAL)) {
-            throw new CustomException(ErrorCode.APPLICATION_DUPLICATED);
+            throw new CustomException(ErrorCode.APPLICATION_CONFLICT);
         }
         return application;
     }

--- a/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
@@ -7,6 +7,7 @@ import com.gdsc_knu.official_homepage.entity.ClassYear;
 import com.gdsc_knu.official_homepage.entity.Member;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
+import com.gdsc_knu.official_homepage.entity.enumeration.Role;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 
 import java.time.LocalDateTime;
@@ -137,5 +138,20 @@ public class ApplicationTestEntityFactory {
             answerList.add(createApplicationAnswerDTO(i, defaultAnswer+i));
         }
         return answerList;
+    }
+
+    public static Member createMember(Long id) {
+        return Member.builder()
+                .id(id)
+                .email(String.format("test%s@email.com", id))
+                .name(String.format("test%s", id))
+                .age((int) (20 + id % 5))
+                .major(String.format("컴퓨터학부-%s", id))
+                .studentNumber(String.format("2024%06d", id))
+                .track(Track.UNDEFINED)
+                .role(Role.ROLE_TEMP)
+                .phoneNumber(String.format("010-0000-%04d", id))
+                .profileUrl(String.format("www.test%s.com", id))
+                .build();
     }
 }

--- a/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
@@ -23,6 +23,17 @@ public class ApplicationTestEntityFactory {
                 .applicationEndDateTime(now.plusDays(1))
                 .build();
     }
+
+    public static ClassYear createExpiredClassYear(Long id) {
+        LocalDateTime now = LocalDateTime.now();
+        return ClassYear.builder()
+                .id(id)
+                .name(String.format("test%s기", id))
+                .applicationStartDateTime(now.minusDays(2))
+                .applicationEndDateTime(now.minusDays(1))
+                .build();
+    }
+
     public static Application createApplication(Long id, Track track, ApplicationStatus status) {
         return Application.builder()
                 .id(id)
@@ -32,19 +43,6 @@ public class ApplicationTestEntityFactory {
                 .phoneNumber(String.format("010-0000-%s", id))
                 .applicationStatus(status)
                 .track(track)
-                .build();
-    }
-
-    public static Application createApplication(Long id, Track track, ApplicationStatus status, List<ApplicationAnswer> answerList) {
-        return Application.builder()
-                .id(id)
-                .email(String.format("test%s@email.com", id))
-                .name(String.format("test%s", id))
-                .studentNumber(String.valueOf(id))
-                .phoneNumber(String.format("010-0000-%s", id))
-                .applicationStatus(status)
-                .track(track)
-                .answers(answerList)
                 .build();
     }
 
@@ -100,5 +98,20 @@ public class ApplicationTestEntityFactory {
                 .answers(answerList)
                 .applicationStatus(ApplicationStatus.TEMPORAL)
                 .build();
+    }
+
+    public static ApplicationAnswerDTO createApplicationAnswerDTO(int questionNumber, String answer) {
+        return ApplicationAnswerDTO.builder()
+                .questionNumber(questionNumber)
+                .answer(answer)
+                .build();
+    }
+
+    public static List<ApplicationAnswerDTO> createApplicationAnswerDTOList(int count, String defaultAnswer) {
+        List<ApplicationAnswerDTO> answerList = new ArrayList<>();
+        for (int i=0; i<count; i++) {
+            answerList.add(createApplicationAnswerDTO(i, defaultAnswer+i));
+        }
+        return answerList;
     }
 }

--- a/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
@@ -65,6 +65,25 @@ public class ApplicationTestEntityFactory {
                 .build();
     }
 
+    public static Application createApplication(Long id, Track track, ApplicationStatus status,
+                                                ClassYear classYear) {
+        return Application.builder()
+                .id(id)
+                .email(String.format("test%s@email.com", id))
+                .name(String.format("test%s", id))
+                .studentNumber(String.valueOf(id))
+                .phoneNumber(String.format("010-0000-%s", id))
+                .major(String.format("컴퓨터학부-%s", id))
+                .techStack("Java")
+                .links("https://github.com")
+                .submittedAt(LocalDateTime.now())
+                .applicationStatus(status)
+                .track(track)
+                .answers(new ArrayList<>())
+                .classYear(classYear)
+                .build();
+    }
+
     public static List<Application> createApplicationList(int startNum, int count, Track track, ApplicationStatus status){
         List<Application> applicationList = new ArrayList<>();
         for (int i=startNum; i<count; i++) {

--- a/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
@@ -22,6 +22,17 @@ public class ApplicationTestEntityFactory {
                 .applicationEndDateTime(now.plusDays(1))
                 .build();
     }
+
+    public static ClassYear createExpiredClassYear(Long id) {
+        LocalDateTime now = LocalDateTime.now();
+        return ClassYear.builder()
+                .id(id)
+                .name(String.format("test%s기", id))
+                .applicationStartDateTime(now.minusDays(2))
+                .applicationEndDateTime(now.minusDays(1))
+                .build();
+    }
+
     public static Application createApplication(Long id, Track track, ApplicationStatus status) {
         return Application.builder()
                 .id(id)

--- a/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
@@ -5,7 +5,6 @@ import com.gdsc_knu.official_homepage.dto.application.ApplicationModel;
 import com.gdsc_knu.official_homepage.dto.application.ApplicationRequest;
 import com.gdsc_knu.official_homepage.entity.ClassYear;
 import com.gdsc_knu.official_homepage.entity.application.Application;
-import com.gdsc_knu.official_homepage.entity.application.ApplicationAnswer;
 import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 
@@ -43,6 +42,7 @@ public class ApplicationTestEntityFactory {
                 .phoneNumber(String.format("010-0000-%s", id))
                 .applicationStatus(status)
                 .track(track)
+                .answers(new ArrayList<>())
                 .build();
     }
 

--- a/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
@@ -23,6 +23,7 @@ public class ApplicationTestEntityFactory {
         return Application.builder()
                 .id(id)
                 .email(String.format("test%s@email.com", id))
+                .name(String.format("test%s", id))
                 .studentNumber(String.valueOf(id))
                 .phoneNumber(String.format("010-0000-%s", id))
                 .applicationStatus(status)

--- a/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
@@ -1,7 +1,11 @@
 package com.gdsc_knu.official_homepage.application;
 
+import com.gdsc_knu.official_homepage.dto.application.ApplicationAnswerDTO;
+import com.gdsc_knu.official_homepage.dto.application.ApplicationModel;
+import com.gdsc_knu.official_homepage.dto.application.ApplicationRequest;
 import com.gdsc_knu.official_homepage.entity.ClassYear;
 import com.gdsc_knu.official_homepage.entity.application.Application;
+import com.gdsc_knu.official_homepage.entity.application.ApplicationAnswer;
 import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 
@@ -31,6 +35,19 @@ public class ApplicationTestEntityFactory {
                 .build();
     }
 
+    public static Application createApplication(Long id, Track track, ApplicationStatus status, List<ApplicationAnswer> answerList) {
+        return Application.builder()
+                .id(id)
+                .email(String.format("test%s@email.com", id))
+                .name(String.format("test%s", id))
+                .studentNumber(String.valueOf(id))
+                .phoneNumber(String.format("010-0000-%s", id))
+                .applicationStatus(status)
+                .track(track)
+                .answers(answerList)
+                .build();
+    }
+
     public static List<Application> createApplicationList(int startNum, int count, Track track, ApplicationStatus status){
         List<Application> applicationList = new ArrayList<>();
         for (int i=startNum; i<count; i++) {
@@ -52,5 +69,36 @@ public class ApplicationTestEntityFactory {
             int classYearIdx = i % classYears.size();
             applications.get(i).updateClassYear(classYears.get(classYearIdx));
         }
+    }
+
+    public static ApplicationRequest createApplicationRequest(Long classYearId) {
+        return ApplicationRequest.builder()
+                .classYearId(classYearId)
+                .techStack("Java")
+                .links("https://github.com")
+                .track(Track.BACK_END)
+                .answers(new ArrayList<>())
+                .applicationStatus(ApplicationStatus.TEMPORAL)
+                .build();
+    }
+
+    public static ApplicationModel createApplicationModel() {
+        return ApplicationModel.builder()
+                .techStack("Java")
+                .links("https://github.com")
+                .track(Track.BACK_END)
+                .answers(new ArrayList<>())
+                .applicationStatus(ApplicationStatus.TEMPORAL)
+                .build();
+    }
+
+    public static ApplicationModel createApplicationModel(List<ApplicationAnswerDTO> answerList) {
+        return ApplicationModel.builder()
+                .techStack("Java")
+                .links("https://github.com")
+                .track(Track.BACK_END)
+                .answers(answerList)
+                .applicationStatus(ApplicationStatus.TEMPORAL)
+                .build();
     }
 }

--- a/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestEntityFactory.java
@@ -4,6 +4,7 @@ import com.gdsc_knu.official_homepage.dto.application.ApplicationAnswerDTO;
 import com.gdsc_knu.official_homepage.dto.application.ApplicationModel;
 import com.gdsc_knu.official_homepage.dto.application.ApplicationRequest;
 import com.gdsc_knu.official_homepage.entity.ClassYear;
+import com.gdsc_knu.official_homepage.entity.Member;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
@@ -41,6 +42,25 @@ public class ApplicationTestEntityFactory {
                 .phoneNumber(String.format("010-0000-%s", id))
                 .applicationStatus(status)
                 .track(track)
+                .build();
+    }
+
+    public static Application createApplication(Long id, Track track, ApplicationStatus status,
+                                                ClassYear classYear, Member member) {
+        return Application.builder()
+                .id(id)
+                .email(member.getEmail())
+                .name(member.getName())
+                .studentNumber(member.getStudentNumber())
+                .phoneNumber(member.getPhoneNumber())
+                .major(member.getMajor())
+                .techStack("Java")
+                .links("https://github.com")
+                .submittedAt(LocalDateTime.now())
+                .applicationStatus(status)
+                .track(track)
+                .answers(new ArrayList<>())
+                .classYear(classYear)
                 .build();
     }
 

--- a/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/ApplicationTestFactory.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ApplicationTestEntityFactory {
+public class ApplicationTestFactory {
     public static ClassYear createClassYear(Long id) {
         LocalDateTime now = LocalDateTime.now();
         return ClassYear.builder()

--- a/src/test/java/com/gdsc_knu/official_homepage/application/domain/ApplicationTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/domain/ApplicationTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
+import static com.gdsc_knu.official_homepage.application.ApplicationTestFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ApplicationTest {

--- a/src/test/java/com/gdsc_knu/official_homepage/application/domain/ApplicationTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/domain/ApplicationTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
-import static com.gdsc_knu.official_homepage.member.MemberTestEntityFactory.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ApplicationTest {

--- a/src/test/java/com/gdsc_knu/official_homepage/application/domain/ApplicationTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/domain/ApplicationTest.java
@@ -1,12 +1,17 @@
 package com.gdsc_knu.official_homepage.application.domain;
 
+import com.gdsc_knu.official_homepage.dto.application.ApplicationAnswerDTO;
+import com.gdsc_knu.official_homepage.entity.Member;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.createApplication;
+import java.util.List;
+
+import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
+import static com.gdsc_knu.official_homepage.member.MemberTestEntityFactory.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ApplicationTest {
@@ -31,5 +36,21 @@ public class ApplicationTest {
         application.updateStatus(ApplicationStatus.APPROVED);
         // then
         assertThat(application.getApplicationStatus()).isEqualTo(ApplicationStatus.TEMPORAL);
+    }
+
+    @Test
+    @DisplayName("지원서 엔티티 생성 시 applicationAnswer와 연관관계 매핑이 된다.")
+    void createApplicationAndAnswerRelationship() {
+        // given
+        int answerCount = 2;
+        Member member = createMember(1L);
+        List<ApplicationAnswerDTO> answerList = createApplicationAnswerDTOList(answerCount, "답변");
+        // when
+        Application application = new Application(member, createApplicationModel(answerList));
+        // then
+        assertThat(application.getAnswers()).hasSize(2);
+        for (int i = 0; i < answerCount; i++) {
+            assertThat(application.getAnswers().get(i).getApplication()).isEqualTo(application);
+        }
     }
 }

--- a/src/test/java/com/gdsc_knu/official_homepage/application/repository/AdminApplicationRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/repository/AdminApplicationRepositoryTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
+import static com.gdsc_knu.official_homepage.application.ApplicationTestFactory.*;
 import static com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus.*;
 import static com.gdsc_knu.official_homepage.entity.enumeration.Track.AI;
 import static com.gdsc_knu.official_homepage.entity.enumeration.Track.BACK_END;

--- a/src/test/java/com/gdsc_knu/official_homepage/application/repository/AdminApplicationRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/repository/AdminApplicationRepositoryTest.java
@@ -8,7 +8,6 @@ import com.gdsc_knu.official_homepage.entity.ClassYear;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.repository.application.ApplicationRepository;
 import com.gdsc_knu.official_homepage.repository.application.ClassYearRepository;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +26,8 @@ import java.util.stream.Stream;
 
 import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
 import static com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus.*;
-import static com.gdsc_knu.official_homepage.entity.enumeration.Track.*;
+import static com.gdsc_knu.official_homepage.entity.enumeration.Track.AI;
+import static com.gdsc_knu.official_homepage.entity.enumeration.Track.BACK_END;
 import static org.assertj.core.api.Assertions.assertThat;
 
 

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
-import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
+import static com.gdsc_knu.official_homepage.application.ApplicationTestFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
 

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
@@ -56,10 +56,9 @@ public class AdminApplicationServiceTest {
     @DisplayName("메일 전송에 실패하더라도 status 변경은 저장한다.(SAVED -> APPROVED)")
     void updateStatus() {
         // given
-        Application application = createApplication(null, Track.AI, ApplicationStatus.SAVED);
         ClassYear classYear = createClassYear(1L);
         classYearRepository.save(classYear);
-        application.updateClassYear(classYear);
+        Application application = createApplication(null, Track.AI, ApplicationStatus.SAVED, classYear);
         applicationRepository.save(application);
         doThrow(CustomException.class).when(mailService).sendEach(any());
         // when
@@ -126,10 +125,9 @@ public class AdminApplicationServiceTest {
     @Test
     @DisplayName("동시에 지원서를 수정하는 경우 처음 시도만 남고 오류를 반환한다.")
     void updateNoteConcurrentFailed() throws InterruptedException {
-        Application application = createApplication(1L, Track.AI, ApplicationStatus.SAVED);
         ClassYear classYear = createClassYear(1L);
         classYearRepository.save(classYear);
-        application.updateClassYear(classYear);
+        Application application = createApplication(1L, Track.AI, ApplicationStatus.SAVED, classYear);
         applicationRepository.saveAndFlush(application);
 
         int threadCount = 2;

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/AdminApplicationServiceTest.java
@@ -1,7 +1,6 @@
 package com.gdsc_knu.official_homepage.application.service;
 
 import com.gdsc_knu.official_homepage.ClearDatabase;
-import com.gdsc_knu.official_homepage.config.QueryDslConfig;
 import com.gdsc_knu.official_homepage.entity.ClassYear;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
@@ -12,7 +11,6 @@ import com.gdsc_knu.official_homepage.repository.application.ApplicationReposito
 import com.gdsc_knu.official_homepage.repository.application.ClassYearRepository;
 import com.gdsc_knu.official_homepage.service.MailService;
 import com.gdsc_knu.official_homepage.service.admin.AdminApplicationService;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -31,10 +28,9 @@ import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
 import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
-import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.setClassYear;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
 
 
 @SpringBootTest

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
@@ -108,8 +108,8 @@ public class ApplicationServiceTest {
         String phoneNumber = member.getPhoneNumber();
 
         // when
-        Application application = applicationRepository.findById(
-                applicationService.saveApplication(member.getEmail(), applicationRequest)).orElseThrow();
+        Long returnedId = applicationService.saveApplication(email, applicationRequest);
+        Application application = applicationRepository.findById(returnedId).orElseThrow();
         // then
         assertThat(application.getClassYear().getId()).isEqualTo(classYearId);
         assertThat(application.getTechStack()).isEqualTo(techStack);

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
@@ -51,13 +51,11 @@ public class ApplicationServiceTest {
     @DisplayName("타인의 지원서를 열람할 경우 예외가 발생한다.")
     void FailedGetApplication() {
         // given
-        Application application = createApplication(null, Track.AI, ApplicationStatus.TEMPORAL);
         ClassYear classYear = createClassYear(1L);
         Member member = createMember(1L);
         classYearRepository.save(classYear);
         memberRepository.save(member);
-        application.updateClassYear(classYear);
-        application.updateApplication(member, createApplicationModel());
+        Application application = createApplication(null, Track.AI, ApplicationStatus.TEMPORAL, classYear, member);
         applicationRepository.save(application);
         Member otherMember = createMember(2L);
         memberRepository.save(otherMember);
@@ -135,13 +133,11 @@ public class ApplicationServiceTest {
     void FailedSaveApplication() {
         // given
         Long classYearId = 1L;
-        Application application = createApplication(null, Track.AI, ApplicationStatus.TEMPORAL);
         ClassYear classYear = createClassYear(classYearId);
         Member member = createMember(1L);
         classYearRepository.save(classYear);
         memberRepository.save(member);
-        application.updateClassYear(classYear);
-        application.updateApplication(member, createApplicationModel());
+        Application application = createApplication(null, Track.AI, ApplicationStatus.TEMPORAL, classYear, member);
         applicationRepository.save(application);
         ApplicationRequest applicationRequest = createApplicationRequest(classYearId);
         // when
@@ -156,13 +152,11 @@ public class ApplicationServiceTest {
     void FailedSaveApplicationDeadline() {
         // given
         Long classYearId = 1L;
-        Application application = createApplication(null, Track.AI, ApplicationStatus.TEMPORAL);
         ClassYear classYear = createExpiredClassYear(1L);
         Member member = createMember(1L);
         classYearRepository.save(classYear);
         memberRepository.save(member);
-        application.updateClassYear(classYear);
-        application.updateApplication(member, createApplicationModel());
+        Application application = createApplication(null, Track.AI, ApplicationStatus.TEMPORAL, classYear, member);
         applicationRepository.save(application);
         ApplicationRequest applicationRequest = createApplicationRequest(classYearId);
         // when
@@ -223,20 +217,11 @@ public class ApplicationServiceTest {
     void FailedUpdateApplication() {
         // given
         Long classYearId = 1L;
-        Application application = createApplication(null, Track.AI, ApplicationStatus.SAVED);
         ClassYear classYear = createClassYear(classYearId);
         Member member = createMember(1L);
         classYearRepository.save(classYear);
         memberRepository.save(member);
-        application.updateClassYear(classYear);
-        ApplicationModel applicationModel = ApplicationModel.builder()
-                .techStack("Java")
-                .links("https://github.com")
-                .track(Track.BACK_END)
-                .answers(new ArrayList<>())
-                .applicationStatus(ApplicationStatus.SAVED)
-                .build();
-        application.updateApplication(member, applicationModel);
+        Application application = createApplication(null, Track.AI, ApplicationStatus.SAVED, classYear, member);
         applicationRepository.save(application);
         ApplicationRequest applicationRequest = createApplicationRequest(classYearId);
         // when
@@ -251,13 +236,11 @@ public class ApplicationServiceTest {
     void FailedUpdateApplicationDeadline() {
         // given
         Long classYearId = 1L;
-        Application application = createApplication(null, Track.AI, ApplicationStatus.TEMPORAL);
         ClassYear classYear = createExpiredClassYear(1L);
         Member member = createMember(1L);
         classYearRepository.save(classYear);
         memberRepository.save(member);
-        application.updateClassYear(classYear);
-        application.updateApplication(member, createApplicationModel());
+        Application application = createApplication(null, Track.AI, ApplicationStatus.TEMPORAL, classYear, member);
         applicationRepository.save(application);
         ApplicationRequest applicationRequest = createApplicationRequest(classYearId);
         // when

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
@@ -1,4 +1,293 @@
 package com.gdsc_knu.official_homepage.application.service;
 
+import com.gdsc_knu.official_homepage.ClearDatabase;
+import com.gdsc_knu.official_homepage.dto.application.ApplicationAnswerDTO;
+import com.gdsc_knu.official_homepage.dto.application.ApplicationRequest;
+import com.gdsc_knu.official_homepage.entity.ClassYear;
+import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.entity.application.Application;
+import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
+import com.gdsc_knu.official_homepage.entity.enumeration.Track;
+import com.gdsc_knu.official_homepage.exception.CustomException;
+import com.gdsc_knu.official_homepage.exception.ErrorCode;
+import com.gdsc_knu.official_homepage.repository.application.ApplicationRepository;
+import com.gdsc_knu.official_homepage.repository.application.ClassYearRepository;
+import com.gdsc_knu.official_homepage.repository.member.MemberRepository;
+import com.gdsc_knu.official_homepage.service.application.ApplicationService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
+import static com.gdsc_knu.official_homepage.member.MemberTestEntityFactory.createMember;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Import(ClearDatabase.class)
 public class ApplicationServiceTest {
+    @Autowired private ApplicationService applicationService;
+    @Autowired private ApplicationRepository applicationRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private ClassYearRepository classYearRepository;
+    @Autowired private ClearDatabase clearDatabase;
+
+    @AfterEach
+    void tearDown() {
+        clearDatabase.each("application");
+        clearDatabase.each("class_year");
+    }
+
+
+    @Test
+    @DisplayName("타인의 지원서를 열람할 경우 예외가 발생한다.")
+    void FailedGetApplication() {
+        // given
+        Application application = createApplication(null, Track.AI, ApplicationStatus.TEMPORAL);
+        ClassYear classYear = createClassYear(1L);
+        Member member = createMember(1L);
+        classYearRepository.save(classYear);
+        memberRepository.save(member);
+        application.updateClassYear(classYear);
+        application.updateApplication(member, createApplicationModel());
+        applicationRepository.save(application);
+        Member otherMember = createMember(2L);
+        memberRepository.save(otherMember);
+        // when
+        CustomException customException = assertThrows(CustomException.class, () ->
+                applicationService.getApplication(member.getEmail(), otherMember.getName(),
+                        otherMember.getStudentNumber(), classYear.getId()));
+        // then
+        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.APPLICATION_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("지원서 정보가 정상적으로 저장(첫제출) 된다.")
+    @Transactional
+    void saveApplication() {
+        // given
+        Long classYearId = 1L;
+        String techStack = "Java";
+        String links = "https://github.com";
+        Track track = Track.BACK_END;
+        ApplicationStatus applicationStatus = ApplicationStatus.TEMPORAL;
+        List<ApplicationAnswerDTO> answerList = List.of(
+                ApplicationAnswerDTO.builder()
+                        .questionNumber(1)
+                        .answer("답변1")
+                        .build(),
+                ApplicationAnswerDTO.builder()
+                        .questionNumber(2)
+                        .answer("답변2")
+                        .build()
+        );
+        ApplicationRequest applicationRequest = ApplicationRequest.builder()
+                .classYearId(classYearId)
+                .techStack(techStack)
+                .links(links)
+                .track(track)
+                .answers(answerList)
+                .applicationStatus(applicationStatus)
+                .build();
+
+        ClassYear classYear = createClassYear(classYearId);
+        Member member = createMember(1L);
+        classYearRepository.save(classYear);
+        memberRepository.save(member);
+
+        String email = member.getEmail();
+        String name = member.getName();
+        String studentNumber = member.getStudentNumber();
+        String major = member.getMajor();
+        String phoneNumber = member.getPhoneNumber();
+
+        // when
+        Application application = applicationRepository.findById(
+                applicationService.saveApplication(member.getEmail(), applicationRequest)).orElseThrow();
+        // then
+        assertThat(application.getClassYear().getId()).isEqualTo(classYearId);
+        assertThat(application.getTechStack()).isEqualTo(techStack);
+        assertThat(application.getLinks()).isEqualTo(links);
+        assertThat(application.getTrack()).isEqualTo(track);
+        assertThat(application.getApplicationStatus()).isEqualTo(applicationStatus);
+        assertThat(application.getEmail()).isEqualTo(email);
+        assertThat(application.getName()).isEqualTo(name);
+        assertThat(application.getStudentNumber()).isEqualTo(studentNumber);
+        assertThat(application.getMajor()).isEqualTo(major);
+        assertThat(application.getPhoneNumber()).isEqualTo(phoneNumber);
+        assertThat(application.getAnswers().size()).isEqualTo(answerList.size());
+        for (int i = 0; i < answerList.size(); i++) {
+            assertThat(application.getAnswers().get(i).getQuestionNumber()).isEqualTo(answerList.get(i).getQuestionNumber());
+            assertThat(application.getAnswers().get(i).getAnswer()).isEqualTo(answerList.get(i).getAnswer());
+        }
+    }
+
+    @Test
+    @DisplayName("동일한 기수에 동일한 지원자가 두 번째 지원서를 첫 제출할 경우 예외가 발생한다.")
+    void FailedSaveApplication() {
+        // given
+        Long classYearId = 1L;
+        ApplicationStatus applicationStatus = ApplicationStatus.TEMPORAL;
+        Application application = createApplication(null, Track.AI, applicationStatus);
+        ClassYear classYear = createClassYear(classYearId);
+        Member member = createMember(1L);
+        classYearRepository.save(classYear);
+        memberRepository.save(member);
+        application.updateClassYear(classYear);
+        application.updateApplication(member, createApplicationModel());
+        applicationRepository.save(application);
+        ApplicationRequest applicationRequest = createApplicationRequest(classYearId);
+        // when
+        CustomException customException = assertThrows(CustomException.class, () ->
+                applicationService.saveApplication(member.getEmail(), applicationRequest));
+        // then
+        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.APPLICATION_DUPLICATED);
+    }
+
+    @Test
+    @DisplayName("데드라인을 넘어서 지원서를 제출 시 예외가 발생한다.")
+    void FailedSaveApplicationDeadline() {
+        // given
+        Long classYearId = 1L;
+        ApplicationStatus applicationStatus = ApplicationStatus.TEMPORAL;
+        Application application = createApplication(null, Track.AI, applicationStatus);
+        LocalDateTime now = LocalDateTime.now();
+        ClassYear classYear = ClassYear.builder()
+                .id(classYearId)
+                .applicationStartDateTime(now.minusDays(2))
+                .applicationEndDateTime(now.minusDays(1))
+                .build();
+        Member member = createMember(1L);
+        classYearRepository.save(classYear);
+        memberRepository.save(member);
+        application.updateClassYear(classYear);
+        application.updateApplication(member, createApplicationModel());
+        applicationRepository.save(application);
+        ApplicationRequest applicationRequest = createApplicationRequest(classYearId);
+        // when
+        CustomException customException = assertThrows(CustomException.class, () ->
+                applicationService.saveApplication(member.getEmail(), applicationRequest));
+        // then
+        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.APPLICATION_DEADLINE_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("지원서 정보가 정상적으로 수정된다.")
+    @Transactional
+    void updateApplication() {
+        // given
+        Long classYearId = 1L;
+        List<ApplicationAnswerDTO> answerList = List.of(
+                ApplicationAnswerDTO.builder()
+                        .questionNumber(0)
+                        .answer("답변1")
+                        .build(),
+                ApplicationAnswerDTO.builder()
+                        .questionNumber(1)
+                        .answer("답변2")
+                        .build()
+        );
+        ClassYear classYear = createClassYear(classYearId);
+        Member member = createMember(1L);
+        classYearRepository.save(classYear);
+        memberRepository.save(member);
+        Application application = new Application(member, createApplicationModel(answerList));
+        application.updateClassYear(classYear);
+        applicationRepository.save(application);
+
+        String email = member.getEmail();
+        String newTechStack = "Python";
+        String newLinks = "https://new-link.com";
+        Track newTrack = Track.FRONT_END;
+        ApplicationStatus newApplicationStatus = ApplicationStatus.SAVED;
+        List<ApplicationAnswerDTO> newAnswerList = List.of(
+                ApplicationAnswerDTO.builder()
+                        .questionNumber(0)
+                        .answer("새로운 답변1")
+                        .build(),
+                ApplicationAnswerDTO.builder()
+                        .questionNumber(1)
+                        .answer("새로운 답변2")
+                        .build()
+        );
+
+        ApplicationRequest applicationUpdateRequest = ApplicationRequest.builder()
+                .classYearId(classYearId) // 기수 정보는 수정 불가
+                .techStack(newTechStack)
+                .links(newLinks)
+                .track(newTrack)
+                .applicationStatus(newApplicationStatus)
+                .answers(newAnswerList)
+                .build();
+        // when
+        Long applicationId = applicationService.updateApplication(email, applicationUpdateRequest);
+        Application updatedApplication = applicationRepository.findById(applicationId).orElseThrow();
+        // then
+        assertThat(updatedApplication.getClassYear().getId()).isEqualTo(classYearId);
+        assertThat(updatedApplication.getTechStack()).isEqualTo(newTechStack);
+        assertThat(updatedApplication.getLinks()).isEqualTo(newLinks);
+        assertThat(updatedApplication.getTrack()).isEqualTo(newTrack);
+        assertThat(updatedApplication.getApplicationStatus()).isEqualTo(newApplicationStatus);
+        assertThat(updatedApplication.getAnswers().size()).isEqualTo(newAnswerList.size());
+        for (int i = 0; i < newAnswerList.size(); i++) {
+            assertThat(updatedApplication.getAnswers().get(i).getQuestionNumber()).isEqualTo(newAnswerList.get(i).getQuestionNumber());
+            assertThat(updatedApplication.getAnswers().get(i).getAnswer()).isEqualTo(newAnswerList.get(i).getAnswer());
+        }
+    }
+
+    @Test
+    @DisplayName("임시 저장 상태가 아닌 지원서를 수정할 경우 예외가 발생한다.")
+    void FailedUpdateApplication() {
+        // given
+        Long classYearId = 1L;
+        ApplicationStatus applicationStatus = ApplicationStatus.SAVED;
+        Application application = createApplication(null, Track.AI, applicationStatus);
+        ClassYear classYear = createClassYear(classYearId);
+        Member member = createMember(1L);
+        classYearRepository.save(classYear);
+        memberRepository.save(member);
+        application.updateClassYear(classYear);
+        application.updateApplication(member, createApplicationModel());
+        applicationRepository.save(application);
+        ApplicationRequest applicationRequest = createApplicationRequest(classYearId);
+        // when
+        CustomException customException = assertThrows(CustomException.class, () ->
+                applicationService.updateApplication(member.getEmail(), applicationRequest));
+        // then
+        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.INVALID_APPLICATION_STATE);
+    }
+
+    @Test
+    @DisplayName("데드라인을 넘어서 지원서를 수정 시 예외가 발생한다.")
+    void FailedUpdateApplicationDeadline() {
+        // given
+        Long classYearId = 1L;
+        ApplicationStatus applicationStatus = ApplicationStatus.TEMPORAL;
+        Application application = createApplication(null, Track.AI, applicationStatus);
+        LocalDateTime now = LocalDateTime.now();
+        ClassYear classYear = ClassYear.builder()
+                .id(classYearId)
+                .applicationStartDateTime(now.minusDays(2))
+                .applicationEndDateTime(now.minusDays(1))
+                .build();
+        Member member = createMember(1L);
+        classYearRepository.save(classYear);
+        memberRepository.save(member);
+        application.updateClassYear(classYear);
+        application.updateApplication(member, createApplicationModel());
+        applicationRepository.save(application);
+        ApplicationRequest applicationRequest = createApplicationRequest(classYearId);
+        // when
+        CustomException customException = assertThrows(CustomException.class, () ->
+                applicationService.updateApplication(member.getEmail(), applicationRequest));
+        // then
+        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.APPLICATION_DEADLINE_EXPIRED);
+    }
 }

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
@@ -46,7 +46,7 @@ public class ApplicationServiceTest {
 
     @Test
     @DisplayName("타인의 지원서를 열람할 경우 예외가 발생한다.")
-    void FailedGetApplication() {
+    void failedGetApplication() {
         // given
         ClassYear classYear = createClassYear(1L);
         Member member = createMember(1L);
@@ -127,7 +127,7 @@ public class ApplicationServiceTest {
 
     @Test
     @DisplayName("동일한 기수에 동일한 지원자가 두 번째 지원서를 첫 제출할 경우 예외가 발생한다.")
-    void FailedSaveApplication() {
+    void failedSaveApplication() {
         // given
         Long classYearId = 1L;
         ClassYear classYear = createClassYear(classYearId);
@@ -146,7 +146,7 @@ public class ApplicationServiceTest {
 
     @Test
     @DisplayName("데드라인을 넘어서 지원서를 제출 시 예외가 발생한다.")
-    void FailedSaveApplicationDeadline() {
+    void failedSaveApplicationDeadline() {
         // given
         Long classYearId = 1L;
         ClassYear classYear = createExpiredClassYear(1L);
@@ -211,7 +211,7 @@ public class ApplicationServiceTest {
 
     @Test
     @DisplayName("임시 저장 상태가 아닌 지원서를 수정할 경우 예외가 발생한다.")
-    void FailedUpdateApplication() {
+    void failedUpdateApplication() {
         // given
         Long classYearId = 1L;
         ClassYear classYear = createClassYear(classYearId);
@@ -230,7 +230,7 @@ public class ApplicationServiceTest {
 
     @Test
     @DisplayName("데드라인을 넘어서 지원서를 수정 시 예외가 발생한다.")
-    void FailedUpdateApplicationDeadline() {
+    void failedUpdateApplicationDeadline() {
         // given
         Long classYearId = 1L;
         ClassYear classYear = createExpiredClassYear(1L);

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
@@ -251,8 +251,7 @@ public class ApplicationServiceTest {
     void FailedUpdateApplicationDeadline() {
         // given
         Long classYearId = 1L;
-        ApplicationStatus applicationStatus = ApplicationStatus.TEMPORAL;
-        Application application = createApplication(null, Track.AI, applicationStatus);
+        Application application = createApplication(null, Track.AI, ApplicationStatus.TEMPORAL);
         ClassYear classYear = createExpiredClassYear(1L);
         Member member = createMember(1L);
         classYearRepository.save(classYear);

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
+import static com.gdsc_knu.official_homepage.application.ApplicationTestFactory.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
@@ -97,15 +97,8 @@ public class ApplicationServiceTest {
         Member member = createMember(1L);
         classYearRepository.save(classYear);
         memberRepository.save(member);
-
-        String email = member.getEmail();
-        String name = member.getName();
-        String studentNumber = member.getStudentNumber();
-        String major = member.getMajor();
-        String phoneNumber = member.getPhoneNumber();
-
         // when
-        Long returnedId = applicationService.saveApplication(email, applicationRequest);
+        Long returnedId = applicationService.saveApplication(member.getEmail(), applicationRequest);
         Application application = applicationRepository.findById(returnedId).orElseThrow();
         // then
         assertThat(application.getClassYear().getId()).isEqualTo(classYearId);
@@ -113,11 +106,11 @@ public class ApplicationServiceTest {
         assertThat(application.getLinks()).isEqualTo(links);
         assertThat(application.getTrack()).isEqualTo(track);
         assertThat(application.getApplicationStatus()).isEqualTo(applicationStatus);
-        assertThat(application.getEmail()).isEqualTo(email);
-        assertThat(application.getName()).isEqualTo(name);
-        assertThat(application.getStudentNumber()).isEqualTo(studentNumber);
-        assertThat(application.getMajor()).isEqualTo(major);
-        assertThat(application.getPhoneNumber()).isEqualTo(phoneNumber);
+        assertThat(application.getEmail()).isEqualTo(member.getEmail());
+        assertThat(application.getName()).isEqualTo(member.getName());
+        assertThat(application.getStudentNumber()).isEqualTo(member.getStudentNumber());
+        assertThat(application.getMajor()).isEqualTo(member.getMajor());
+        assertThat(application.getPhoneNumber()).isEqualTo(member.getPhoneNumber());
         assertThat(application.getAnswers().size()).isEqualTo(answerList.size());
         for (int i = 0; i < answerList.size(); i++) {
             assertThat(application.getAnswers().get(i).getQuestionNumber()).isEqualTo(answerList.get(i).getQuestionNumber());

--- a/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/application/service/ApplicationServiceTest.java
@@ -2,7 +2,6 @@ package com.gdsc_knu.official_homepage.application.service;
 
 import com.gdsc_knu.official_homepage.ClearDatabase;
 import com.gdsc_knu.official_homepage.dto.application.ApplicationAnswerDTO;
-import com.gdsc_knu.official_homepage.dto.application.ApplicationModel;
 import com.gdsc_knu.official_homepage.dto.application.ApplicationRequest;
 import com.gdsc_knu.official_homepage.entity.ClassYear;
 import com.gdsc_knu.official_homepage.entity.Member;
@@ -23,11 +22,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.gdsc_knu.official_homepage.application.ApplicationTestEntityFactory.*;
-import static com.gdsc_knu.official_homepage.member.MemberTestEntityFactory.createMember;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/src/test/java/com/gdsc_knu/official_homepage/member/MemberTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/member/MemberTestEntityFactory.java
@@ -1,0 +1,33 @@
+package com.gdsc_knu.official_homepage.member;
+
+import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.entity.enumeration.Role;
+import com.gdsc_knu.official_homepage.entity.enumeration.Track;
+
+public class MemberTestEntityFactory {
+    public static Member createMember(Long id) {
+        return Member.builder()
+                .id(id)
+                .email(String.format("test%s@email.com", id))
+                .name(String.format("test%s", id))
+                .age((int) (20 + id % 5))
+                .studentNumber(String.format("2024%06d", id))
+                .track(Track.UNDEFINED)
+                .role(Role.ROLE_TEMP)
+                .phoneNumber(String.format("010-0000-%04d", id))
+                .build();
+    }
+
+    public static Member createMember(Long id, String name, Track track, Role role) {
+        return Member.builder()
+                .id(id)
+                .age((int) (20 + id % 5))
+                .email(String.format("test%s@email.com", id))
+                .name(name)
+                .studentNumber(String.format("2024%06d", id))
+                .track(track)
+                .role(role)
+                .phoneNumber(String.format("010-0000-%04d", id))
+                .build();
+    }
+}

--- a/src/test/java/com/gdsc_knu/official_homepage/member/MemberTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/member/MemberTestEntityFactory.java
@@ -11,23 +11,27 @@ public class MemberTestEntityFactory {
                 .email(String.format("test%s@email.com", id))
                 .name(String.format("test%s", id))
                 .age((int) (20 + id % 5))
+                .major(String.format("컴퓨터학부-%s", id))
                 .studentNumber(String.format("2024%06d", id))
                 .track(Track.UNDEFINED)
                 .role(Role.ROLE_TEMP)
                 .phoneNumber(String.format("010-0000-%04d", id))
+                .profileUrl(String.format("www.test%s.com", id))
                 .build();
     }
 
     public static Member createMember(Long id, String name, Track track, Role role) {
         return Member.builder()
                 .id(id)
-                .age((int) (20 + id % 5))
                 .email(String.format("test%s@email.com", id))
                 .name(name)
+                .age((int) (20 + id % 5))
+                .major(String.format("컴퓨터학부-%s", id))
                 .studentNumber(String.format("2024%06d", id))
                 .track(track)
                 .role(role)
                 .phoneNumber(String.format("010-0000-%04d", id))
+                .profileUrl(String.format("www.test%s.com", id))
                 .build();
     }
 }

--- a/src/test/java/com/gdsc_knu/official_homepage/member/domain/MemberTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/member/domain/MemberTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static com.gdsc_knu.official_homepage.member.MemberTestEntityFactory.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,7 +40,7 @@ public class MemberTest {
     @DisplayName("최초 가입 정보 입력 후 GUEST 권한을 획득할 수 있다")
     void addNewMemberInfo() {
         // given
-        Member member = createMember();
+        Member member = createMember(1L);
         MemberRequest.Append request = new MemberRequest.Append("새로운 이름",24,"2000123456", "컴퓨터학부","010-1111-1111");
 
         // when
@@ -51,17 +52,5 @@ public class MemberTest {
         assertThat(member.getStudentNumber()).isEqualTo("2000123456");
         assertThat(member.getMajor()).isEqualTo("컴퓨터학부");
         assertThat(member.getRole()).isEqualTo(Role.ROLE_GUEST);
-    }
-
-
-    public Member createMember() {
-        return Member.builder()
-                .role(Role.ROLE_TEMP)
-                .track(Track.UNDEFINED)
-                .email("test@email.com")
-                .name("테스트이름")
-                .profileUrl("http://test.png")
-                .phoneNumber("010-0000-0000")
-                .build();
     }
 }

--- a/src/test/java/com/gdsc_knu/official_homepage/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/member/repository/MemberRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
+import static com.gdsc_knu.official_homepage.member.MemberTestEntityFactory.createMember;
 import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
@@ -65,14 +66,5 @@ public class MemberRepositoryTest {
             assertThat(member.getTrack()).isEqualTo(Track.BACK_END);
             assertThat(member.getRole()).isEqualTo(Role.ROLE_GUEST);
         });
-    }
-
-    private Member createMember(Long id, String name, Track track, Role role) {
-        return Member.builder()
-                .name(name)
-                .email(String.format("test%s@email.com", id))
-                .track(track)
-                .role(role)
-                .build();
     }
 }

--- a/src/test/java/com/gdsc_knu/official_homepage/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/member/repository/MemberRepositoryTest.java
@@ -1,10 +1,12 @@
 package com.gdsc_knu.official_homepage.member.repository;
 
+import com.gdsc_knu.official_homepage.ClearDatabase;
 import com.gdsc_knu.official_homepage.config.QueryDslConfig;
 import com.gdsc_knu.official_homepage.entity.Member;
 import com.gdsc_knu.official_homepage.entity.enumeration.Role;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 import com.gdsc_knu.official_homepage.repository.member.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,9 +19,15 @@ import static com.gdsc_knu.official_homepage.member.MemberTestEntityFactory.crea
 import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
-@Import(QueryDslConfig.class)
+@Import({QueryDslConfig.class, ClearDatabase.class})
 public class MemberRepositoryTest {
     @Autowired private MemberRepository memberRepository;
+    @Autowired private ClearDatabase clearDatabase;
+
+    @AfterEach
+    void tearDown() {
+        clearDatabase.each("member");
+    }
 
     @Test
     @DisplayName("직렬별 사용자를 이름으로 정렬하여 조회한다. MEMBER 만 조회된다.")

--- a/src/test/java/com/gdsc_knu/official_homepage/member/service/MemberServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/member/service/MemberServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
+import static com.gdsc_knu.official_homepage.member.MemberTestEntityFactory.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -102,15 +103,6 @@ public class MemberServiceTest {
         // then
         assertThat(response.size()).isEqualTo(2);
         assertThat(response.stream().map(TeamResponse.Main::getTeamName)).containsExactly("부모2 1팀", "부모1 1팀");
-    }
-
-    private Member createMember(Long id) {
-        return Member.builder()
-                .name("이름")
-                .email(String.format("test%s@email.com", id))
-                .track(Track.UNDEFINED)
-                .role(Role.ROLE_TEMP)
-                .build();
     }
 
     private Team parentTeam(String teamName) {

--- a/src/test/java/com/gdsc_knu/official_homepage/team/TeamTestEntityFactory.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/team/TeamTestEntityFactory.java
@@ -1,0 +1,31 @@
+package com.gdsc_knu.official_homepage.team;
+
+import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.entity.Team;
+import com.gdsc_knu.official_homepage.entity.enumeration.Role;
+import com.gdsc_knu.official_homepage.entity.enumeration.Track;
+
+public class TeamTestEntityFactory {
+    public static Team createTeam(Long id, Team parent) {
+        return Team.builder()
+                .id(id)
+                .teamName("팀 이름")
+                .parent(parent)
+                .build();
+    }
+
+    public static Member createMember(Long id) {
+        return Member.builder()
+                .id(id)
+                .email(String.format("test%s@email.com", id))
+                .name(String.format("test%s", id))
+                .age((int) (20 + id % 5))
+                .major(String.format("컴퓨터학부-%s", id))
+                .studentNumber(String.format("2024%06d", id))
+                .track(Track.UNDEFINED)
+                .role(Role.ROLE_TEMP)
+                .phoneNumber(String.format("010-0000-%04d", id))
+                .profileUrl(String.format("www.test%s.com", id))
+                .build();
+    }
+}

--- a/src/test/java/com/gdsc_knu/official_homepage/team/service/AdminTeamServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/team/service/AdminTeamServiceTest.java
@@ -3,8 +3,6 @@ package com.gdsc_knu.official_homepage.team.service;
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamRequest;
 import com.gdsc_knu.official_homepage.entity.Member;
 import com.gdsc_knu.official_homepage.entity.Team;
-import com.gdsc_knu.official_homepage.entity.enumeration.Role;
-import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 import com.gdsc_knu.official_homepage.repository.member.MemberRepository;
 import com.gdsc_knu.official_homepage.repository.team.MemberTeamRepository;
 import com.gdsc_knu.official_homepage.repository.team.TeamRepository;
@@ -20,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.gdsc_knu.official_homepage.member.MemberTestEntityFactory.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -65,16 +64,6 @@ public class AdminTeamServiceTest {
         assertThat(parent.getSubTeams().get(0).getParent()).isEqualTo(parent);
         assertThat(parent.getSubTeams().get(0).getTeamName()).isEqualTo(String.format("%s 1팀", parent.getTeamName()));
 
-    }
-
-    private Member createMember(Long id) {
-        return  Member.builder()
-                .id(id)
-                .email("test@email.com")
-                .name("테스트 유저")
-                .track(Track.BACK_END)
-                .role(Role.ROLE_MEMBER)
-                .build();
     }
 
     private Team createTeam(Long id, Team parent) {

--- a/src/test/java/com/gdsc_knu/official_homepage/team/service/AdminTeamServiceTest.java
+++ b/src/test/java/com/gdsc_knu/official_homepage/team/service/AdminTeamServiceTest.java
@@ -18,7 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.gdsc_knu.official_homepage.member.MemberTestEntityFactory.createMember;
+import static com.gdsc_knu.official_homepage.team.TeamTestEntityFactory.createMember;
+import static com.gdsc_knu.official_homepage.team.TeamTestEntityFactory.createTeam;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -66,11 +67,5 @@ public class AdminTeamServiceTest {
 
     }
 
-    private Team createTeam(Long id, Team parent) {
-        return Team.builder()
-                .id(id)
-                .teamName("팀 이름")
-                .parent(parent)
-                .build();
-    }
+
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 지원서 관련 테스트 코드 작성
- 일반 예외 처리에서 CustomException 처리로 변경
- 테스트 공통 메서드 추출

## To Reviewers 📢
- 멤버 테스트 공통 메서드를 오버로딩해서 추출했습니다. 틀렸거나, 좀 더 나은 구조가 있다면 말씀해주세요(7bb7c6ec3f5839371c1ea1d22c46e2f5eaebc63b)
- 저번에도 에러가 터져서 Application 생성자에 ApplicationAnswer와 연관관계 누락된걸 수정해뒀는데... 어디서 다시 되돌아간지 모르겠네요... 다시 돌려뒀습니다.(babf756ce04869cd5e4f66c2e18bfa8b90a5cf5e)


## 체크 리스트
- [x] 테스트를 작성했습니다.
- [x] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [x] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #152 