### PR TITLE
타임리프 사용 API CORS 수정

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
@@ -31,7 +31,6 @@ public class SecurityConfig {
 
     private static final String[] WHITE_LIST = {
             "/api/post/{postId:\\d+}/comment/**",
-            "/api/post/trending",
             "/api/post/**"
     };
     private static final String[] MEMBER_AUTHENTICATION_LIST = {

--- a/src/main/java/com/gdsc_knu/official_homepage/config/WebConfig.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.gdsc_knu.official_homepage.config;
 
 import com.gdsc_knu.official_homepage.annotation.TokenMemberResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -13,12 +14,17 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
+    @Value("${white-list.name1}")
+    String server_name1;
+    @Value("${white-list.name2}")
+    String server_name2;
+
     private final TokenMemberResolver tokenMemberResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173","https://gdsc-knu.com","https://gdsc-knu.shop")
+                .allowedOrigins("http://localhost:5173","https://gdsc-knu.com",server_name1, server_name2)
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .exposedHeaders("Access-Control-Allow-Origin", "Access-Control-Allow-Credentials")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,6 @@ logging:
     webhook-url: ${DISCORD_WEBHOOK_URL:default}
     attendance-webhook-url: ${DISCORD_ATTENDANCE_WEBHOOK_URL:default}
 
+white-list:
+  name1: ${SERVER_PROD_IP:localhost}
+  name2: ${SERVER_PROD_DOMAIN:localhost}


### PR DESCRIPTION
## 🔎 작업 내용
- 자신의 서버로 요청을 보내는 경우 서버의 도메인이 CORS에 의해 차단되는 오류를 수정
  - (타임리프 (세미나 출석 알림) 사용 시 본 서버로 post 요청을 보낼때 오류 발생)

## To Reviewers 📢
- 서버의 ip와 도메인을 .env 에 업데이트 했습니다.

## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #159 